### PR TITLE
Create an explicit dependency on Microsoft's extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
       "type": "git",
       "url": "https://github.com/docker/vscode-extension"
   },
+  "extensionDependencies": [
+    "ms-azuretools.vscode-docker"
+  ],
   "activationEvents": [
     "onLanguage:dockerbake",
     "onLanguage:dockercompose",


### PR DESCRIPTION
## Problem Description

We want users who install our extension to also install Microsoft's extension.

## Proposed Solution

Create an explicit dependency by using the `extensionDependencies` attribute in the `package.json` as documented [here](https://code.visualstudio.com/api/references/extension-manifest).

## Proof of Work

Will validate the change by using what GHA generates as a VSIX file.