### PR TITLE
Use records instead of Records

### DIFF
--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -70,6 +70,6 @@ export function publishTelemetry(): void {
       response.on('end', () => {});
     },
   );
-  request.write(JSON.stringify({ Records: records }));
+  request.write(JSON.stringify({ records }));
   request.end();
 }


### PR DESCRIPTION
## Problem Description

The endpoint prefers the JSON payload to use `records` instead of `Records`.

## Proposed Solution

Change the JSON payload to use `records` instead of `Records`.

## Proof of Work

Confirmed with the data team that this is what we should do going forward.