### PR TITLE
Consider the case where docker is not on the PATH

### DIFF
--- a/src/utils/monitor.ts
+++ b/src/utils/monitor.ts
@@ -43,6 +43,10 @@ function checkDockerStatus(): Promise<DockerEngineStatus> {
     s.stderr.on('data', (chunk) => {
       output += String(chunk);
     });
+    s.on('error', () => {
+      // this happens if docker cannot be found on the PATH
+      return resolve(DockerEngineStatus.Unavailable);
+    });
     s.on('exit', (code) => {
       if (code === 0) {
         return resolve(DockerEngineStatus.Available);


### PR DESCRIPTION
## Problem Description

When `docker` is not on the `PATH` the extension "hangs" and never completes its activation step.

## Proposed Solution

If `docker` is not on the `PATH` then we will get an `'error'` event instead of an `'exit'` event with a non-zero exit code. We need to catch that case and then let the user know they need to install Docker Desktop.

## Proof of Work

<img width="510" alt="image" src="https://github.com/user-attachments/assets/ce70d63d-d192-4fea-8532-15e2314f18cf" />

If I use `docker2` instead we can see that the `'error'` event is hit.