### PR TITLE
Record the case where docker is not found on the PATH

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,6 +163,13 @@ function recordVersionTelemetry(featureFlag: string | undefined) {
   process.stdout.on('data', (data) => {
     versionString = String(data).trim();
   });
+  process.on('error', () => {
+    // this happens if docker cannot be found on the PATH
+    queueTelemetryEvent('client_heartbeat', false, {
+      docker_version: 'spawn docker -v failed',
+      feature_flag: featureFlag,
+    });
+  });
   process.on('exit', (code) => {
     if (code === 0) {
       queueTelemetryEvent('client_heartbeat', false, {


### PR DESCRIPTION
## Problem Description

If `docker` cannot be found on the `PATH` we do not send a `client_heartbeat` event.

## Proposed Solution

We should still send a `client_heartbeat` event back if docker could not be found on the `PATH`. Fixed by handling the `"error"` event on the spawned process.

## Proof of Work

Reproduced by using `docker2` instead (which does not exist on my `PATH`).

<img width="667" alt="image" src="https://github.com/user-attachments/assets/4d4df8ec-100b-4dce-bd1a-bc611bdc09fe" />