### PR TITLE
Fail and notify the user if the docker desktop CLI cannot run

### DIFF
--- a/src/utils/monitor.ts
+++ b/src/utils/monitor.ts
@@ -76,7 +76,12 @@ function getDockerDesktopPath(): string {
 
 async function isDockerDesktopInstalled(): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
-    spawn('docker', ['desktop', 'version']).on('exit', (code) => {
+    const s = spawn('docker', ['desktop', 'version']);
+    s.on('error', () => {
+      // this happens if docker cannot be found on the PATH
+      resolve(false);
+    });
+    s.on('exit', (code) => {
       if (code === 0) {
         return resolve(true);
       }


### PR DESCRIPTION
## Problem Description

If `docker` cannot be found on the `PATH` then the `docker desktop` CLI command will not complete. In that case our code is stuck because the promise is never resolved.

## Proposed Solution

Catch the `"error"` event case where `docker` cannot be found on the `PATH` and resolving the promise will ensure that the user is prompted to install Docker Desktop.

## Proof of Work

Reproduced by temporarily changing the code to call `docker2 desktop version` (where `docker2 naturally cannot be found on my `PATH`).

<img width="612" alt="image" src="https://github.com/user-attachments/assets/0d4f0628-d4b9-4cf1-9be3-de9c57e4e7b7" />