### PR TITLE
Enforce file formatting when a file is saved

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,13 @@
 // Place your settings in this file to overwrite default and user settings.
 {
+	"editor.formatOnSave": true,
+	"[typescriptreact]": {
+	  "editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[typescript]": {
+	  "editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"typescript.updateImportsOnFileMove.enabled": "always",
 	"files.exclude": {
 		"out": false, // set this to true to hide the "out" folder with the compiled JS files
 		"dist": false // set this to true to hide the "dist" folder with the compiled JS files


### PR DESCRIPTION
## Problem Description

I saved a file but it didn't format it for me. :(

## Proposed Solution

Asked @stanislavHamara for help and he mentioned adding some lines to the `settings.json`. :) This will help ensure consistency across the codebase and remove unnecessary conflicts between different versions of the file.

## Proof of Work

I confirm that I tested this change. :)