### PR TITLE
Include the version of the extension in the telemetry

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,8 @@ let unleashClient: any = null;
 
 export const BakeBuildCommandId = 'dockerLspClient.bake.build';
 
+export let extensionVersion: string;
+
 const activateDockerLSP = async (ctx: vscode.ExtensionContext) => {
   ctx.subscriptions.push(
     vscode.commands.registerCommand(
@@ -50,6 +52,8 @@ const activateDockerLSP = async (ctx: vscode.ExtensionContext) => {
 };
 
 export function activate(ctx: vscode.ExtensionContext) {
+  extensionVersion = String(ctx.extension.packageJSON.version);
+
   const configValue = vscode.workspace
     .getConfiguration('docker.extension.experimental.release')
     .get<string>('march2025');

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -1,6 +1,7 @@
 import https from 'https';
 import * as process from 'process';
 import * as vscode from 'vscode';
+import { extensionVersion } from '../extension';
 
 interface TelemetryRecord {
   event: string;
@@ -38,6 +39,7 @@ export function queueTelemetryEvent(
   properties.client_name = 'vscode';
   properties.machine_id = vscode.env.machineId;
   properties.client_session = vscode.env.sessionId;
+  properties.extension_version = extensionVersion;
 
   events.push({
     event,


### PR DESCRIPTION
## Problem Description

We do not currently include the extension's version number in our telemetry.

## Proposed Solution

Add the version number in the telemetry event.

## Proof of Work

Verified by debugging that the value is correct.