### PR TITLE
Add the operating system and the extension's version to the feature flag context

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,7 +73,14 @@ export function activate(ctx: vscode.ExtensionContext) {
       clientKey: 'changeme',
       appName: 'vscode-extension',
     });
-    client.updateContext({ userId: vscode.env.machineId });
+    client.updateContext({
+      userId: vscode.env.machineId,
+      properties: {
+        vscodeExtensionVersion: extensionVersion,
+        operatingSystem:
+          process.platform === 'win32' ? 'windows' : process.platform,
+      },
+    });
     client.on('ready', () => {
       if (client.isEnabled('VSCodeReleaseMarch2025')) {
         activateExtension(ctx);


### PR DESCRIPTION
## Problem Description

The current approach does not give us enough flexibility over how we rollout the extension to our users.

## Proposed Solution

Adding the user's operating system and the version of the extension will give us finer control over how we rollout the extension.

## Proof of Work

I tested it by toggling the feature flag around in Unleashed and swapping the context around with the following JavaScript file.

```JavaScript
const unleashLibrary = require('unleash-proxy-client');
const client = new unleashLibrary.UnleashClient({
    url: 'https://hub.docker.com/v2/feature-flags/proxy/',
    clientKey: 'changeme',
    appName: 'vscode-extension',
});
client.updateContext({ properties: { operatingSystem: "linux", vscodeExtensionVersion: "0.0.21" } });
client.on('ready', () => {
    console.log(client.isEnabled('VSCodeReleaseMarch2025'));
    client.stop();
    process.exit(0);
});
client.start();
```