### PR TITLE
Fix the path for uploading the artifact to the GitHub release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,4 +111,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: docker-vscode-extension/docker-vscode-extension-${{ matrix.nodeos }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}.vsix
+          files: vscode-extension/docker-vscode-extension-${{ matrix.nodeos }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}.vsix


### PR DESCRIPTION
## Problem Description

The [v0.0.21 build](https://github.com/docker/vscode-extension/actions/runs/13998712291) completed but no artifacts were uploaded to the [release](https://github.com/docker/vscode-extension/releases/tag/v0.0.21).

```
2025-03-21T18:43:45.5665414Z 🤔 Pattern 'docker-vscode-extension/docker-vscode-extension-darwin-x64-0.0.21.vsix' does not match any files.
2025-03-21T18:43:45.7462523Z Found release v0.0.21 (with id=207518691)
2025-03-21T18:43:45.8858277Z 🤔 docker-vscode-extension/docker-vscode-extension-darwin-x64-0.0.21.vsix not include valid file.
2025-03-21T18:43:45.8865151Z 🎉 Release ready at https://github.com/docker/vscode-extension/releases/tag/v0.0.21
2025-03-21T18:43:45.8972187Z Post job cleanup.
```

## Proposed Solution

Fix the `files` attribute so that it references the right file to upload.

## Proof of Work

This is a GHA change and cannot be easily verified.