### PR TITLE
Document what kind of telemetry is collected

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,4 @@ To debug the VS Code extension:
 
 ## Telemetry
 
-This extension collects telemetry. You can configue the telemetry you would like to send by changing the `docker.lsp.telemetry` setting. Note that if `vscode.env.isTelemetryEnabled` returns `false` then telemetry will not be sent regardless of the value of the `docker.lsp.telemetry` setting.
-
-Read our [privacy policy](https://www.docker.com/legal/docker-privacy-policy/) to learn more about how the information is collected and used.
+See [TELEMETRY.md](./TELEMETRY.md) for details about what kind of telemetry we collect and how to configure your telemetry settings.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,30 @@
+# Telemetry
+
+This Visual Studio Code extension collects telemetry. We collect this telemetry so that we can improve the extension by understanding usage patterns and catching crashes and errors for diagnostic purposes.
+
+## Configuring Telemetry Collection
+
+You can configue the telemetry you would like to send by changing the `docker.lsp.telemetry` setting. This can be one of three values:
+
+- `"all"` - all telemetry will be sent
+- `"error"` - send only errors and crash information
+- `"off"` - stop all telemetry from being sent
+
+If you have already opted out of sending telemetry in Visual Studio Code then no telemetry will be sent to Docker regardless of the value of the `docker.lsp.telemetry` setting.
+
+## Telemetry Data Collected
+
+- operating system
+- CPU architecture
+- application name
+- `vscode.env.machineId`
+- `vscode.env.sessionId`
+- version of the installed extension
+- Docker version
+- function names and parameters for diagnosing errors and crashes
+
+The list above does _not_ include any telemetry collected by the [Docker Language Server](https://github.com/docker/docker-language-server). For telemetry collected by the Docker Language Server, please refer to the telemetry documentation of that project.
+
+## Privacy Policy
+
+Read our [privacy policy](https://www.docker.com/legal/docker-privacy-policy/) to learn more about how the information is collected and used.


### PR DESCRIPTION
## Problem Description

There is no clear breakdown of the telemetry that is being collected by the extension.

## Proposed Solution

Create a dedicated `TELEMETRY.md` document to outline what kind of telemetry the extension collects.

## Proof of Work

This is a documentation change. :) See [here](https://github.com/docker/vscode-extension/blob/8ca56acf4b73c02bab2539be43ef19168fa91fe9/TELEMETRY.md) for a rendered version of the proposed `TELEMETRY.md` file.