### PR TITLE
Exclude unnecessary folders from the VSIX file

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,7 +1,9 @@
+.github/**
 .vscode/**
 .vscode-test/**
-out/**
 node_modules/**
+out/**
+resources/readme/**
 src/**
 .gitignore
 .yarnrc


### PR DESCRIPTION
## Problem Description

1. `.github` workflows do not need to be included in the VSIX build.
2. `README.md` images are loaded from GitHub so they also do not need to be included in the VSIX build.

See #30.

## Proposed Solution

Added the two aforementioned folders to `.vscodeignore`.

## Proof of Work

I ran `vsce package` with and without the command verified that the change works.

```
 INFO  Files included in the VSIX:
docker-0.1.1.vsix
├─ [Content_Types].xml
├─ extension.vsixmanifest
└─ extension/
   ├─ Dockerfile [0.43 KB]
   ├─ LICENSE.txt [10.51 KB]
   ├─ SECURITY.md [1.82 KB]
   ├─ TELEMETRY.md [1.34 KB]
   ├─ changelog.md [0.48 KB]
   ├─ docker-compose.yml [0.37 KB]
   ├─ frontend.Dockerfile [0.02 KB]
   ├─ notes.md [0.52 KB]
   ├─ package.json [3.7 KB]
   ├─ readme.md [4.83 KB]
   ├─ tmp.js [0.72 KB]
   ├─ bin/
   │  ├─ docker-language-server-darwin-arm64 [39.69 MB]
   │  └─ docker-language-server-linux-arm64 [38.36 MB]
   ├─ dist/
   │  ├─ 1.extension.js [21.23 KB]
   │  ├─ 770.extension.js [20.65 KB]
   │  └─ extension.js [349.74 KB]
   └─ resources/
      └─ docker-logo-vertical-blue.png [244.23 KB]
```