### PR TITLE
Hide "Build with Bake" command by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "commands": [
       {
         "title": "Build with Bake",
-        "command": "dockerLspClient.bake.build"
+        "command": "dockerLspClient.bake.build",
+        "enablement": "never"
       }
     ],
     "languages": [


### PR DESCRIPTION
## Problem Description

The "Build with Bake" command is showing up in the Command Palette and it does not run if you try to execute it.

## Proposed Solution

We do not want this command to be available from the Command Palette so we should set its enablement attribute to "never". We may want to surface this in the future but we can cross that bridge when we get there.

This fix will resolve #32.

## Proof of Work

Verified that it no longer shows up in the Command Palette.

<img width="390" alt="image" src="https://github.com/user-attachments/assets/517c0e0d-acba-4ab0-9caf-26ffc1b120e2" />