### PR TITLE
Toggle supportHtml so that tables can be rendered in HTML

### DIFF
--- a/src/utils/lsp/lsp.ts
+++ b/src/utils/lsp/lsp.ts
@@ -122,7 +122,7 @@ async function createNative(ctx: vscode.ExtensionContext): Promise<boolean> {
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     markdown: {
       isTrusted: false,
-      supportHtml: false,
+      supportHtml: true,
     },
     middleware: {
       workspace: {


### PR DESCRIPTION
## Problem Description

When you have something like `golang:1.23.7`, hovering will show "Recommeneded tags" but nothing will be shown.

## Proposed Solution

We have `<table>` HTML tags in the hover output. These will need the `supportHtml` property set in order for VS Code to render them instead of ignoring and stripping them out from the hovered content.

Closes #34.

## Proof of Work

![image](https://github.com/user-attachments/assets/fb2b9f1c-928c-4b8d-bc94-2bc38d690aa9)