### PR TITLE
Add a menu item to scan images for CVEs with Docker Scout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Docker DX extension will be documented in this file.
 ### Added
 
 - Include the feature flag's value in the telemetry event ([#39](https://github.com/docker/vscode-extension/issues/39))
+- Contribute a context menu item to ms-azuretools.vscode-docker to scan an image with Docker Scout ([#38](https://github.com/docker/vscode-extension/issues/38))
 
 ### Changed
 
@@ -15,7 +16,6 @@ All notable changes to the Docker DX extension will be documented in this file.
 ### Fixed
 
 - Running "Build with Bake" without a Bakefile yields an error ([#32](https://github.com/docker/vscode-extension/issues/32))
-
 - Has "tag recommendations available" but doesn't actually show what tags are recommended ([#34](https://github.com/docker/vscode-extension/issues/34))
 
 ## 0.1.1 - 2025-03-26

--- a/package.json
+++ b/package.json
@@ -30,8 +30,11 @@
     "commands": [
       {
         "title": "Build with Bake",
-        "command": "dockerLspClient.bake.build",
-        "enablement": "never"
+        "command": "dockerLspClient.bake.build"
+      },
+      {
+        "title": "Scan for CVEs with Docker Scout",
+        "command": "docker.scout.imageScan"
       }
     ],
     "languages": [
@@ -43,6 +46,15 @@
         ]
       }
     ],
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "docker.scout.imageScan",
+          "when": "view == dockerImages && viewItem == image",
+          "group": "images_group_dockerdx"
+        }
+      ]
+    },
     "configuration": {
       "title": "Docker",
       "properties": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "commands": [
       {
         "title": "Build with Bake",
-        "command": "dockerLspClient.bake.build"
+        "command": "dockerLspClient.bake.build",
+        "enablement": "never"
       },
       {
         "title": "Scan for CVEs with Docker Scout",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       },
       {
         "title": "Scan for CVEs with Docker Scout",
-        "command": "docker.scout.imageScan"
+        "command": "docker.scout.imageScan",
+        "enablement": "view == dockerImages && viewItem == image"
       }
     ],
     "languages": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,38 +13,99 @@ const unleashLibrary = import('unleash-proxy-client');
 let unleashClient: any = null;
 
 export const BakeBuildCommandId = 'dockerLspClient.bake.build';
+export const ScoutImageScanCommandId = 'docker.scout.imageScan';
 
 export let extensionVersion: string;
 
-const activateDockerLSP = async (ctx: vscode.ExtensionContext) => {
-  ctx.subscriptions.push(
-    vscode.commands.registerCommand(
-      BakeBuildCommandId,
-      async (commandArgs: { [key: string]: string }) => {
-        const args = ['buildx', 'bake'];
+function registerCommands(ctx: vscode.ExtensionContext) {
+  registerCommand(ctx, BakeBuildCommandId, (commandArgs: any) => {
+    return new Promise((resolve) => {
+      const process = spawn('docker', ['buildx', 'bake', '--help']);
+      process.on('error', () => {
+        resolve(false);
+      });
+      process.on('exit', (code) => {
+        if (code === 0) {
+          const args = ['buildx', 'bake'];
 
-        if (commandArgs['call'] === 'print') {
-          args.push('--print');
-          args.push(commandArgs['target']);
+          if (commandArgs['call'] === 'print') {
+            args.push('--print');
+            args.push(commandArgs['target']);
+          } else {
+            args.push('--call');
+            args.push(commandArgs['call']);
+            args.push(commandArgs['target']);
+          }
+
+          const task = new vscode.Task(
+            { type: 'shell' },
+            vscode.TaskScope.Workspace,
+            'docker buildx bake',
+            'docker-vscode-extension',
+            new vscode.ShellExecution('docker', args, {
+              cwd: commandArgs['cwd'],
+            }),
+          );
+          vscode.tasks.executeTask(task);
+          resolve(true);
         } else {
-          args.push('--call');
-          args.push(commandArgs['call']);
-          args.push(commandArgs['target']);
+          resolve(false);
         }
+      });
+    });
+  });
 
-        const task = new vscode.Task(
-          { type: 'shell' },
-          vscode.TaskScope.Workspace,
-          'docker buildx bake',
-          'docker-vscode-extension',
-          new vscode.ShellExecution('docker', args, {
-            cwd: commandArgs['cwd'],
-          }),
-        );
-        await vscode.tasks.executeTask(task);
-      },
-    ),
+  registerCommand(ctx, ScoutImageScanCommandId, (args) => {
+    return new Promise((resolve) => {
+      const process = spawn('docker', ['scout']);
+      process.on('error', () => {
+        resolve(false);
+      });
+      process.on('exit', (code) => {
+        if (code === 0) {
+          const task = new vscode.Task(
+            { type: 'shell' },
+            vscode.TaskScope.Workspace,
+            'docker scout',
+            'docker scout',
+            new vscode.ShellExecution(
+              'docker',
+              ['scout', 'cves', args.fullTag],
+              {},
+            ),
+          );
+          vscode.tasks.executeTask(task);
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      });
+    });
+  });
+}
+
+function registerCommand(
+  ctx: vscode.ExtensionContext,
+  id: string,
+  commandCallback: (...args: any[]) => Promise<boolean>,
+): void {
+  ctx.subscriptions.push(
+    vscode.commands.registerCommand(id, async (args) => {
+      if (args === undefined) {
+        return;
+      }
+
+      const result = await commandCallback(args);
+      queueTelemetryEvent('client_user_action', false, {
+        action_id: id,
+        result,
+      });
+    }),
   );
+}
+
+const activateDockerLSP = async (ctx: vscode.ExtensionContext) => {
+  registerCommands(ctx);
 
   if (await activateDockerNativeLanguageClient(ctx)) {
     getNativeClient().start();
@@ -59,6 +120,35 @@ export function activate(ctx: vscode.ExtensionContext) {
     .get<string>('march2025');
   if (configValue === 'disabled') {
     recordVersionTelemetry(configValue, 'ignored');
+
+    // register the Scout command even if the extension is disabled as it will show up in the UI
+    registerCommand(ctx, ScoutImageScanCommandId, (args) => {
+      return new Promise((resolve) => {
+        const process = spawn('docker', ['scout']);
+        process.on('error', () => {
+          resolve(false);
+        });
+        process.on('exit', (code) => {
+          if (code === 0) {
+            const task = new vscode.Task(
+              { type: 'shell' },
+              vscode.TaskScope.Workspace,
+              'docker scout',
+              'docker scout',
+              new vscode.ShellExecution(
+                'docker',
+                ['scout', 'cves', args.fullTag],
+                {},
+              ),
+            );
+            vscode.tasks.executeTask(task);
+            resolve(true);
+          } else {
+            resolve(false);
+          }
+        });
+      });
+    });
     return;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,10 +91,6 @@ function registerCommand(
 ): void {
   ctx.subscriptions.push(
     vscode.commands.registerCommand(id, async (args) => {
-      if (args === undefined) {
-        return;
-      }
-
       const result = await commandCallback(args);
       queueTelemetryEvent('client_user_action', false, {
         action_id: id,


### PR DESCRIPTION
## Problem Description

It would be helpful if we could scan images for CVEs with the `docker scout` command from the UI.

## Proposed Solution

We will contribute a context menu item to Microsoft's extension to run `docker scout cves ...` on the selected image.

## Proof of Work

![image](https://github.com/user-attachments/assets/9ad04c85-303b-4cd6-a7d1-85d67692818d)