### PR TITLE
Suppress duplicated Dockerfile diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- suppress duplicated errors that are reported by both the Dockerfile Language Server and the Docker Language Server ([#33](https://github.com/docker/vscode-extension/issues/33))
+
 ## [0.2.0] - 2025-03-28
 
 ### Added

--- a/src/utils/lsp/languageClient.ts
+++ b/src/utils/lsp/languageClient.ts
@@ -16,6 +16,9 @@ export class DockerLanguageClient extends LanguageClient {
     super.fillInitializeParams(params);
     const dockerConfiguration = vscode.workspace.getConfiguration('docker.lsp');
     params.initializationOptions = {
+      dockerfileExperimental: {
+        removeOverlappingIssues: true,
+      },
       telemetry: getTelemetryValue(dockerConfiguration.get('telemetry')),
     };
     params.capabilities.experimental = {


### PR DESCRIPTION
## Problem Description

If both the Dockerfile Language Server and the Docker Language Server is running then some diagnostics will be duplicated across both language servers.

## Proposed Solution

We will use a new experimental setting to suppress the duplicated errors from the Docker Language Server.

Closes #33.

## Proof of Work

We can see from this image that the `MaintainerDeprecated` error is not getting reported by twice but we still get the `JSONArgsRecommended` warning.

![image](https://github.com/user-attachments/assets/32d87cee-8e69-4ad4-8ab4-8914f2dfea1f)