### PR TITLE
Add a description to the extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docker",
   "displayName": "Docker DX",
-  "description": "",
+  "description": "Edit smarter, ship faster with an enhanced Docker-development experience",
   "version": "0.2.0",
   "icon": "resources/docker-logo-vertical-blue.png",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Problem Description

When searching for the extension, we have no description which can make it harder for people to understand why they should install the extension.

![image](https://github.com/user-attachments/assets/37218037-ccbd-422e-94cd-70a62622e617)

## Proposed Solution

Add a description to `package.json`.

## Proof of Work

Debugging does not seem to change the description but this is where I see the text in other VS Code extensions so I believe this is the place.