### PR TITLE
Register the Scout command regardless of any user setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Docker DX extension will be documented in this file.
 
 - suppress duplicated errors that are reported by both the Dockerfile Language Server and the Docker Language Server ([#33](https://github.com/docker/vscode-extension/issues/33))
 
+### Fixed
+
+- always register the Scout command so that the gradual rollout will not prevent the command from working ([#44](https://github.com/docker/vscode-extension/issues/44))
+
 ## [0.2.0] - 2025-03-28
 
 ### Added

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,34 +54,6 @@ function registerCommands(ctx: vscode.ExtensionContext) {
       });
     });
   });
-
-  registerCommand(ctx, ScoutImageScanCommandId, (args) => {
-    return new Promise((resolve) => {
-      const process = spawn('docker', ['scout']);
-      process.on('error', () => {
-        resolve(false);
-      });
-      process.on('exit', (code) => {
-        if (code === 0) {
-          const task = new vscode.Task(
-            { type: 'shell' },
-            vscode.TaskScope.Workspace,
-            'docker scout',
-            'docker scout',
-            new vscode.ShellExecution(
-              'docker',
-              ['scout', 'cves', args.fullTag],
-              {},
-            ),
-          );
-          vscode.tasks.executeTask(task);
-          resolve(true);
-        } else {
-          resolve(false);
-        }
-      });
-    });
-  });
 }
 
 function registerCommand(
@@ -109,6 +81,35 @@ const activateDockerLSP = async (ctx: vscode.ExtensionContext) => {
 };
 
 export function activate(ctx: vscode.ExtensionContext) {
+  // always register the Scout command even so that it is always available regardless of the rollout stage
+  registerCommand(ctx, ScoutImageScanCommandId, (args) => {
+    return new Promise((resolve) => {
+      const process = spawn('docker', ['scout']);
+      process.on('error', () => {
+        resolve(false);
+      });
+      process.on('exit', (code) => {
+        if (code === 0) {
+          const task = new vscode.Task(
+            { type: 'shell' },
+            vscode.TaskScope.Workspace,
+            'docker scout',
+            'docker scout',
+            new vscode.ShellExecution(
+              'docker',
+              ['scout', 'cves', args.fullTag],
+              {},
+            ),
+          );
+          vscode.tasks.executeTask(task);
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      });
+    });
+  });
+
   extensionVersion = String(ctx.extension.packageJSON.version);
 
   const configValue = vscode.workspace
@@ -116,35 +117,6 @@ export function activate(ctx: vscode.ExtensionContext) {
     .get<string>('march2025');
   if (configValue === 'disabled') {
     recordVersionTelemetry(configValue, 'ignored');
-
-    // register the Scout command even if the extension is disabled as it will show up in the UI
-    registerCommand(ctx, ScoutImageScanCommandId, (args) => {
-      return new Promise((resolve) => {
-        const process = spawn('docker', ['scout']);
-        process.on('error', () => {
-          resolve(false);
-        });
-        process.on('exit', (code) => {
-          if (code === 0) {
-            const task = new vscode.Task(
-              { type: 'shell' },
-              vscode.TaskScope.Workspace,
-              'docker scout',
-              'docker scout',
-              new vscode.ShellExecution(
-                'docker',
-                ['scout', 'cves', args.fullTag],
-                {},
-              ),
-            );
-            vscode.tasks.executeTask(task);
-            resolve(true);
-          } else {
-            resolve(false);
-          }
-        });
-      });
-    });
     return;
   }
 


### PR DESCRIPTION
## Problem Description

If you install the extension now, the Scout command will now work if the `docker.extension.experimental.release.march2025` setting is set to `featureFlag`.

## Proposed Solution

Explicitly registering the command regardless of any feature flag or setting will help resolve this issue.

Fixes #44.

## Proof of Work

![image](https://github.com/user-attachments/assets/e208f5d9-f7bf-4a8f-9a3a-843c4e80c485)