### PR TITLE
Check commits are signed

### DIFF
--- a/.github/scripts/check-commits.sh
+++ b/.github/scripts/check-commits.sh
@@ -12,7 +12,7 @@ for sha in $commits; do
   message=$(git log -1 --pretty=format:%B "$sha")
 
   if echo "$message" | grep -Eq "$signoff_regex"; then
-    echo "✔ Signed-off-by line found."
+    echo "✔ 'Signed-off-by' message found."
     continue
   fi
 
@@ -22,7 +22,7 @@ for sha in $commits; do
     continue
   fi
 
-  echo "::error file=.git/COMMIT_EDITMSG::❌ Commit $sha is missing both a valid Signed-off-by line and a verified GPG signature."
+  echo "::error file=.git/COMMIT_EDITMSG::❌ Commit $sha is missing both a valid Signed-off-by message and a verified GPG signature."
   missing=$((missing + 1))
 done
 

--- a/.github/scripts/check-commits.sh
+++ b/.github/scripts/check-commits.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+signoff_regex="^Signed-off-by: [A-Za-z .'-]+ <[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}>$"
+commits=$(gh pr view "$1" --json commits -q ".commits[].oid")
+
+missing=0
+
+for sha in $commits; do
+  echo "🔍 Checking commit $sha..."
+  message=$(git log -1 --pretty=format:%B "$sha")
+
+  if echo "$message" | grep -Eq "$signoff_regex"; then
+    echo "✔ Signed-off-by line found."
+    continue
+  fi
+
+  is_verified=$(gh api repos/${GITHUB_REPOSITORY}/commits/$sha --jq '.commit.verification.verified')
+  if [ "$is_verified" = "true" ]; then
+    echo "✔ Verified GPG signature found."
+    continue
+  fi
+
+  echo "::error file=.git/COMMIT_EDITMSG::❌ Commit $sha is missing both a valid Signed-off-by line and a verified GPG signature."
+  missing=$((missing + 1))
+done
+
+if [ "$missing" -gt 0 ]; then
+  echo "❌ Some commits are not properly signed."
+  exit 1
+fi
+
+echo "✅ All commits are properly signed."

--- a/.github/scripts/check-commits.sh
+++ b/.github/scripts/check-commits.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-signoff_regex="^Signed-off-by: [A-Za-z .'-]+ <[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}>$"
+signoff_regex="Signed-off-by:"
 commits=$(gh pr view "$1" --json commits -q ".commits[].oid")
 
 missing=0
@@ -11,7 +11,7 @@ for sha in $commits; do
   echo "🔍 Checking commit $sha..."
   message=$(git log -1 --pretty=format:%B "$sha")
 
-  if echo "$message" | grep -Eq "$signoff_regex"; then
+  if echo "$message" | grep -q "$signoff_regex"; then
     echo "✔ 'Signed-off-by' message found."
     continue
   fi

--- a/.github/scripts/check-commits.sh
+++ b/.github/scripts/check-commits.sh
@@ -18,11 +18,11 @@ for sha in $commits; do
 
   is_verified=$(gh api repos/${GITHUB_REPOSITORY}/commits/$sha --jq '.commit.verification.verified')
   if [ "$is_verified" = "true" ]; then
-    echo "✔ Verified GPG signature found."
+    echo "✔ Verified signature found."
     continue
   fi
 
-  echo "::error file=.git/COMMIT_EDITMSG::❌ Commit $sha is missing both a valid Signed-off-by message and a verified GPG signature."
+  echo "::error file=.git/COMMIT_EDITMSG::❌ Commit $sha is missing either a valid Signed-off-by message or a verified (GPG, SSH, or S/MIME) signature."
   missing=$((missing + 1))
 done
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,8 +1,8 @@
-name: Verify Signed-off-by or GPG Signature
-
+name: Verify commit signatures
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    branches:
+      - '**'
 
 jobs:
   check-commits:
@@ -13,35 +13,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check each commit for sign-off or GPG signature
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run commit sign-off check script
         run: |
-          signoff_regex="^Signed-off-by: [A-Za-z .'-]+ <[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}>$"
-          commits=$(gh pr view ${{ github.event.pull_request.number }} --json commits -q ".commits[].oid")
-
-          missing=0
-
-          for sha in $commits; do
-            echo "🔍 Checking commit $sha..."
-            message=$(git log -1 --pretty=format:%B "$sha")
-
-            if echo "$message" | grep -Eq "$signoff_regex"; then
-              echo "✔ Signed-off-by line found."
-              continue
-            fi
-
-            is_verified=$(gh api repos/${{ github.repository }}/commits/$sha --jq '.commit.verification.verified')
-            if [ "$is_verified" = "true" ]; then
-              echo "✔ Verified GPG signature found."
-              continue
-            fi
-
-            echo "::error file=.git/COMMIT_EDITMSG::❌ Commit $sha is missing both a valid Signed-off-by line and a verified GPG signature."
-            missing=$((missing + 1))
-          done
-
-          if [ "$missing" -gt 0 ]; then
-            echo "❌ Some commits are not properly signed."
-            exit 1
-          fi
+          .github/scripts/check-commits.sh "${{ github.event.pull_request.number }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,47 @@
+name: Verify Signed-off-by or GPG Signature
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check each commit for sign-off or GPG signature
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          signoff_regex="^Signed-off-by: [A-Za-z .'-]+ <[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}>$"
+          commits=$(gh pr view ${{ github.event.pull_request.number }} --json commits -q ".commits[].oid")
+
+          missing=0
+
+          for sha in $commits; do
+            echo "🔍 Checking commit $sha..."
+            message=$(git log -1 --pretty=format:%B "$sha")
+
+            if echo "$message" | grep -Eq "$signoff_regex"; then
+              echo "✔ Signed-off-by line found."
+              continue
+            fi
+
+            is_verified=$(gh api repos/${{ github.repository }}/commits/$sha --jq '.commit.verification.verified')
+            if [ "$is_verified" = "true" ]; then
+              echo "✔ Verified GPG signature found."
+              continue
+            fi
+
+            echo "::error file=.git/COMMIT_EDITMSG::❌ Commit $sha is missing both a valid Signed-off-by line and a verified GPG signature."
+            missing=$((missing + 1))
+          done
+
+          if [ "$missing" -gt 0 ]; then
+            echo "❌ Some commits are not properly signed."
+            exit 1
+          fi

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,4 @@
 name: Verify commit signatures
-
 on:
   pull_request:
     branches:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,4 +1,5 @@
 name: Verify commit signatures
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Problem Description

We would like all contributors to adhere to https://github.com/docker/vscode-extension/blob/main/CONTRIBUTING.md and sign their commits

## Proposed Solution

Introduce a GHA that checks that a commit has been signed by either a "Signed-off" message or with a verified GPG, SSH, or S/MIME signature.

## Proof of Work

Tested:
 - signed with GPG
 - turned off GPG and signed off in a commit message
 - removed a verified signature from a commit to trigger a GHA failure

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/0721fa8b-5613-4c3b-9b9c-2b359f6fc805" />


<!--
This can be pasted output from the terminal or a screenshot demonstrating the proposed change.
If this is non-trivial to "prove" (GHA build YAML changes) or unnecessary (documentation changes and so on) for whatever reasons, a statement explaining the unwieldy nature of providing a proof of work is sufficient.
-->
