### PR TITLE
Download a binary of the language server with npm install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,23 +54,6 @@ jobs:
           SHA=$(git rev-parse --short HEAD)
           echo "SHA=$SHA" >> "$GITHUB_OUTPUT"
 
-      - name: actions/checkout@v4 (docker/docker-language-server)
-        uses: actions/checkout@v4
-        with:
-          repository: docker/docker-language-server
-          path: docker-language-server
-
-      - working-directory: docker-language-server
-        run: |
-          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
-
-      - working-directory: vscode-extension
-        run: mkdir bin
-
-      - working-directory: docker-language-server
-        run: |
-          mv ./docker-language-server-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }} ../vscode-extension/bin/
-
       - name: Build the extension (refs/heads)
         if: startsWith(github.ref, 'refs/heads')
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- automatically download a binary of the language server when `npm install` is run to make development a little easier
+
 ## [0.3.0]
 
 ### Changed
@@ -49,6 +55,7 @@ All notable changes to the Docker DX extension will be documented in this file.
   - error reporting
 - Compose outline support
 
+[Unreleased]: https://github.com/docker/vscode-extension/compare/v0.3.0...main
 [0.3.0]: https://github.com/docker/vscode-extension/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/docker/vscode-extension/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/docker/vscode-extension/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -68,12 +68,7 @@ Note: The language server binary from these builds are not signed and/or notariz
 
 ## Development
 
-To debug the VS Code extension:
-
-1. Clone this repository.
-2. Open the folder in VS Code.
-3. Create a `bin` folder at the root.
-4. Download the [Docker Language Server binary](https://github.com/docker/docker-language-server) and place it in `bin/` Alternatively, follow the instructions in that repository and build a binary yourself to place in the `bin` folder.
+To debug the VS Code extension, clone this repository and then run `npm install`. This will download a binary of the [Docker Language Server](https://github.com/docker/docker-language-server/releases) to the `bin` folder. If you would like to test your own custom build of the language server, simply replace the file in the `bin` folder with your own binary.
 
 ### Debugging both the extension and language server
 

--- a/build/downloader.mjs
+++ b/build/downloader.mjs
@@ -49,7 +49,9 @@ async function downloadSyntaxesFile() {
 
 async function downloadLanguageServerBinary() {
   if (process.arch !== 'x64' && process.arch !== 'arm64') {
-    console.error(`No language server binary can be found for the ${process.arch} architecture.`);
+    console.error(
+      `No language server binary can be found for the ${process.arch} architecture.`,
+    );
     process.exit(1);
   }
 

--- a/build/downloader.mjs
+++ b/build/downloader.mjs
@@ -23,24 +23,46 @@ async function downloadFile(url, dest) {
   }
 }
 
-async function run() {
+async function run(directory, url, file) {
   const cwd = path.resolve(__dirname);
   const buildDir = path.basename(cwd);
   const repoDir = cwd.replace(buildDir, '');
-  const installPath = path.join(repoDir, 'syntaxes');
+  const installPath = path.join(repoDir, directory);
 
   if (fs.existsSync(installPath)) {
     if (process.env.downloader_log === 'true') {
-      console.info(`Syntax path exists at ${installPath}. Removing`);
+      console.info(`Target folder path exists at ${installPath}. Removing`);
     }
     fs.rmSync(installPath, { recursive: true });
   }
 
   fs.mkdirSync(installPath);
 
-  const hclSyntaxFile = `hcl.tmGrammar.json`;
-  const url = `https://github.com/hashicorp/syntax/releases/download/v0.7.1/${hclSyntaxFile}`;
-  await downloadFile(url, path.join(installPath, hclSyntaxFile));
+  await downloadFile(url, path.join(installPath, file));
 }
 
-run();
+async function downloadSyntaxesFile() {
+  const hclSyntaxFile = `hcl.tmGrammar.json`;
+  const url = `https://github.com/hashicorp/syntax/releases/download/v0.7.1/${hclSyntaxFile}`;
+  run('syntaxes', url, hclSyntaxFile);
+}
+
+async function downloadLanguageServerBinary() {
+  if (process.arch !== 'x64' && process.arch !== 'arm64') {
+    console.error(`No language server binary can be found for the ${process.arch} architecture.`);
+    process.exit(1);
+  }
+
+  const platform = process.platform;
+  const arch = process.arch === 'x64' ? 'amd64' : 'arm64';
+  const suffix = platform === 'win32' ? '.exe' : '';
+  const version = '0.2.0';
+  const binaryFile = `docker-language-server-${platform}-${arch}-v${version}${suffix}`;
+  const targetFile = `docker-language-server-${platform}-${arch}${suffix}`;
+  const url = `https://github.com/docker/docker-language-server/releases/download/v${version}/${binaryFile}${suffix}`;
+  await run('bin', url, targetFile);
+  fs.chmodSync(`bin/${targetFile}`, 0o755);
+}
+
+downloadSyntaxesFile();
+downloadLanguageServerBinary();


### PR DESCRIPTION
## Problem Description

Currently, any developer interested in looking at the VS Code extension has to download a binary of the Docker Language Server manually.

## Proposed Solution

We can remove the aforementioned extra manual step by reusing `downloader.mjs` to download and place a binary of the Docker Language Server into the `bin` folder for us.

## Proof of Work

```

> docker@0.3.0 prepare
> npm run download:artifacts


> docker@0.3.0 download:artifacts
> node build/downloader.mjs

Downloading https://github.com/hashicorp/syntax/releases/download/v0.7.1/hcl.tmGrammar.json...
Saving to /workspaces/vscode-extension/syntaxes/hcl.tmGrammar.json...
Downloading https://github.com/docker/docker-language-server/releases/download/v0.2.0/docker-language-server-linux-arm64-v0.2.0...
Saving to /workspaces/vscode-extension/bin/docker-language-server-linux-arm64...

up to date, audited 529 packages in 3s

129 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```