### PR TITLE
Append to versionString instead of overriding it

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -236,7 +236,10 @@ function recordVersionTelemetry(
   let versionString: string | null = null;
   const process = spawn('docker', ['-v']);
   process.stdout.on('data', (data) => {
-    versionString = String(data).trim();
+    if (versionString === null) {
+      versionString = '';
+    }
+    versionString += String(data).trim();
   });
   process.on('error', () => {
     // this happens if docker cannot be found on the PATH


### PR DESCRIPTION
## Problem Description

The `versionString` capture code currently assumes that we will get all of the data from stdout in one event.

## Proposed Solution

Appending to `versionString` instead of assigning the event's data will ensure we have captured everything we want to capture.

## Proof of Work

There is unfortunately no easy way to test this.