### PR TITLE
Remove unleash-proxy-client as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "unleash-proxy-client": "3.7.3",
         "vscode-languageclient": "9.0.1"
       },
       "devDependencies": {
@@ -7023,12 +7022,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "license": "MIT"
-    },
     "node_modules/tmp": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -7243,16 +7236,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/unleash-proxy-client": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.7.3.tgz",
-      "integrity": "sha512-Cd7ovrhAIpwveNFdtpzs7HO0WeArC2fbjIVGL2Cjza8bHD+jJ1JbSuy3tFuKvvUkbVKq/EGV0RgosEa/3UVLgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tiny-emitter": "^2.1.0",
-        "uuid": "^9.0.1"
-      }
-    },
     "node_modules/unzipper": {
       "version": "0.12.3",
       "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
@@ -7328,19 +7311,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "prettier:fix": "prettier --write --config .prettierrc.yml --ignore-path .prettierignore ."
   },
   "dependencies": {
-    "unleash-proxy-client": "3.7.3",
     "vscode-languageclient": "9.0.1"
   },
   "devDependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,10 +8,6 @@ import { DidChangeConfigurationNotification } from 'vscode-languageclient/node';
 import { publishTelemetry, queueTelemetryEvent } from './telemetry/client';
 import { checkForDockerEngine } from './utils/monitor';
 
-const unleashLibrary = import('unleash-proxy-client');
-
-let unleashClient: any = null;
-
 export const BakeBuildCommandId = 'dockerLspClient.bake.build';
 export const ScoutImageScanCommandId = 'docker.scout.imageScan';
 
@@ -235,10 +231,6 @@ function recordVersionTelemetry(
 }
 
 export async function deactivate() {
-  if (unleashClient !== null) {
-    unleashClient.stop();
-    unleashClient = null;
-  }
   const client = getNativeClient();
   if (client !== undefined) {
     client.stop();


### PR DESCRIPTION
## Problem Description

We still depend on `unleash-proxy-client` even though we do not use feature flags anywhere.

## Proposed Solution

Remove the code... :)

## Proof of Work

Hard to prove this one... :S