### PR TITLE
Capture error messages that we recognize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- include recognizable error messages in the telemetry data
+
 ## [0.4.1] - 2025-04-08
 
 ### Removed

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -22,6 +22,7 @@ If you have already opted out of sending telemetry in Visual Studio Code then no
 - version of the installed extension
 - Docker version
 - function names and parameters for diagnosing errors and crashes
+- error messages when the language server is unable to start or is crashing
 
 The list above does _not_ include any telemetry collected by the [Docker Language Server](https://github.com/docker/docker-language-server). For telemetry collected by the Docker Language Server, please refer to the telemetry documentation of that project.
 

--- a/src/utils/lsp/languageClient.ts
+++ b/src/utils/lsp/languageClient.ts
@@ -38,6 +38,7 @@ export class DockerLanguageClient extends LanguageClient {
     showNotification?: boolean | 'force',
   ): void {
     queueTelemetryEvent('client_heartbeat', true, {
+      message: filterMessage(message),
       error_function: 'DockerLanguageClient.error',
       show_notification: showNotification,
     });
@@ -67,6 +68,7 @@ export class DockerLanguageClient extends LanguageClient {
         const result: any = handler.closed();
         if (result.action !== undefined) {
           queueTelemetryEvent('client_heartbeat', true, {
+            message: filterMessage(result.message),
             error_function: 'ErrorHandler.closed',
             action: result.action,
           });
@@ -75,4 +77,16 @@ export class DockerLanguageClient extends LanguageClient {
       },
     };
   }
+}
+
+function filterMessage(message: string): string {
+  if (
+    message ===
+      'The Docker Language Server server crashed 5 times in the last 3 minutes. The server will not be restarted. See the output for more information.' ||
+    message ===
+      "Docker Language Server client: couldn't create connection to server."
+  ) {
+    return message;
+  }
+  return 'unrecognized';
 }


### PR DESCRIPTION
## Problem Description

We currently only capture error counts but we have no context as to what kind of errors users are hitting.

## Proposed Solution

We will add strict tests for messages to see if we recognize them. If we do then we'll include it in the telemetry as there is no ambiguity as to what kind of errors they are.

## Proof of Work

Confirmed in the debugger...