### PR TITLE
Run docker commands even if they will fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- surface errors with Docker Bake or Docker Scout to the user instead of failing silently
+
 ## [0.4.2] - 2025-04-08
 
 ### Changed


### PR DESCRIPTION
## Problem Description

Currently, if `docker` is unavailable then the commands will fail silently instead of notifying the user.

## Proposed Solution

Refactored the code so that it will always try to run the command even if it is doomed to fail.

## Proof of Work

Tested by temporarily renaming `docker` to `docker2` in the debugger.

<img width="892" alt="image" src="https://github.com/user-attachments/assets/5bfdead8-3284-4bd6-aa05-6f429505b304" />