### PR TITLE
Update downloader.mjs to get v0.3.0 of the language server

### DIFF
--- a/build/downloader.mjs
+++ b/build/downloader.mjs
@@ -58,7 +58,7 @@ async function downloadLanguageServerBinary() {
   const platform = process.platform;
   const arch = process.arch === 'x64' ? 'amd64' : 'arm64';
   const suffix = platform === 'win32' ? '.exe' : '';
-  const version = '0.2.0';
+  const version = '0.3.0';
   const binaryFile = `docker-language-server-${platform}-${arch}-v${version}${suffix}`;
   const targetFile = `docker-language-server-${platform}-${arch}${suffix}`;
   const url = `https://github.com/docker/docker-language-server/releases/download/v${version}/${binaryFile}${suffix}`;


### PR DESCRIPTION
## Problem Description

I forgot to update `downloader.mjs` for the builds... :(

## Proposed Solution

Updated the numbers in `downloader.mjs`.

## Proof of Work

```
$ npm i

> docker@0.4.2 prepare
> npm run download:artifacts


> docker@0.4.2 download:artifacts
> node build/downloader.mjs

Downloading https://github.com/hashicorp/syntax/releases/download/v0.7.1/hcl.tmGrammar.json...
Saving to /Users/rcjsuen/code/docker/vscode-extension/syntaxes/hcl.tmGrammar.json...
Downloading https://github.com/docker/docker-language-server/releases/download/v0.3.0/docker-language-server-darwin-arm64-v0.3.0...
Saving to /Users/rcjsuen/code/docker/vscode-extension/bin/docker-language-server-darwin-arm64...

up to date, audited 621 packages in 3s

156 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```