### PR TITLE
Correct the README.md to note that it is the extension's requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The **Docker DX (Developer Experience)** Visual Studio Code extension enhances y
 
 The extension requires Docker Engine to be running. [Install Docker Desktop](https://www.docker.com/get-started/) on your machine and make sure the `docker` CLI is available in your system `PATH`.
 
-Docker currently supports the following operating systems and architectures:
+This extension currently supports the following operating systems and architectures:
 
 | Operating system | Architectures    |
 | ---------------- | ---------------- |


### PR DESCRIPTION
## Problem Description

The table in the readme incorrectly called out Docker instead of the extension.

## Proposed Solution

Fixed the typo... :)

## Proof of Work

This is a documentation change. The corrected file can be found [here](https://github.com/docker/vscode-extension/blob/833c5968c64f88f4b7382d143464f9153a0c5754/README.md).