### PR TITLE
Explain that the Docker DX extension is installed with Microsoft's extension as a pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The **Docker DX (Developer Experience)** Visual Studio Code extension enhances your Visual Studio Code experience with Docker-related development by adding rich editing features and vulnerability scanning.
 
+The Docker DX extension is shipped as part of [Microsoft's Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) as an optional dependency.
+
 ## Key features
 
 - [Dockerfile linting](https://docs.docker.com/reference/build-checks/): Get build warnings and best-practice suggestions via BuildKit and BuildX.


### PR DESCRIPTION
## Problem Description

It is unclear to users why the Docker DX extension has been installed onto their systems.

## Proposed Solution

We'll add a blurb at the top of `README.md` so people know where it is coming from.

## Proof of Work

This is a documentation change.