### PR TITLE
Run Scout task with the user's home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- pick the user's home folder when scanning for CVEs with Scout if no workspace folder has been opened ([#76](https://github.com/docker/vscode-extension/issues/76))
+
 ## [0.4.5] - 2025-04-09
 
 ### Fixed

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { homedir } from 'os';
 import * as vscode from 'vscode';
 import {
   activateDockerNativeLanguageClient,
@@ -58,12 +59,23 @@ function registerCommands(ctx: vscode.ExtensionContext) {
         resolve(code === 0);
       });
     });
+    const options: vscode.ShellExecutionOptions = {};
+    if (
+      vscode.workspace.workspaceFolders === undefined ||
+      vscode.workspace.workspaceFolders.length === 0
+    ) {
+      options.cwd = homedir();
+    }
     const task = new vscode.Task(
       { type: 'shell' },
       vscode.TaskScope.Workspace,
       'docker scout',
       'docker scout',
-      new vscode.ShellExecution('docker', ['scout', 'cves', args.fullTag], {}),
+      new vscode.ShellExecution(
+        'docker',
+        ['scout', 'cves', args.fullTag],
+        options,
+      ),
     );
     vscode.tasks.executeTask(task);
     return result;


### PR DESCRIPTION
## Problem Description

If no workspace folder has been opened then the task cannot run because it does not know which folder to use as the working directory.

See https://github.com/microsoft/vscode-docker/issues/4552.

## Proposed Solution

In this case, we should just use the user's home directory.

Fixes #76.

## Proof of Work

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/21e3be80-becc-45a1-b20a-78d6e8521506" />