### PR TITLE
Update to the 0.3.5 release of the language server

### DIFF
--- a/build/downloader.mjs
+++ b/build/downloader.mjs
@@ -58,7 +58,7 @@ async function downloadLanguageServerBinary() {
   const platform = process.platform;
   const arch = process.arch === 'x64' ? 'amd64' : 'arm64';
   const suffix = platform === 'win32' ? '.exe' : '';
-  const version = '0.3.4';
+  const version = '0.3.5';
   const binaryFile = `docker-language-server-${platform}-${arch}-v${version}${suffix}`;
   const targetFile = `docker-language-server-${platform}-${arch}${suffix}`;
   const url = `https://github.com/docker/docker-language-server/releases/download/v${version}/${binaryFile}${suffix}`;


### PR DESCRIPTION
This doesn't change anything in the VS Code extension as it just includes a fix for an issue with the implementation of the specification (that affects other editors but VS Code itself seems to ignore the error).