### PR TITLE
Capture language server startup errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- capture errors from the language server not being able to start
+
 ## [0.4.7] - 2025-04-11
 
 ### Fixed


### PR DESCRIPTION
## Problem Description

The language server is unable to start on some systems but we have not been able to identify the reason. We also have not received any reports about the language server not starting.

## Proposed Solution

We will capture the rejected promise and try to extract information from that to better understand what might be going on.

## Proof of Work

For example, if the file cannot be found for some reason, we can identify this with the `ENOENT` error code.

![image](https://github.com/user-attachments/assets/a67d7d2d-cff0-471c-9c79-6900dcce8592)