### PR TITLE
Fix the client's response to workspace/configuration

### DIFF
--- a/src/utils/lsp/lsp.ts
+++ b/src/utils/lsp/lsp.ts
@@ -127,16 +127,15 @@ async function createNative(ctx: vscode.ExtensionContext): Promise<boolean> {
     middleware: {
       workspace: {
         configuration: (params, token, next) => {
-          const result = next(params, token) as any;
-          return [
-            {
+          const result = next(params, token) as any[];
+          return result.map((value) => {
+            return {
               experimental: {
-                vulnerabilityScanning:
-                  result[0].experimental.vulnerabilityScanning,
+                vulnerabilityScanning: value.experimental.vulnerabilityScanning,
               },
-              telemetry: getTelemetryValue(result[0].telemetry),
-            },
-          ];
+              telemetry: getTelemetryValue(value.telemetry),
+            };
+          });
         },
       },
     },


### PR DESCRIPTION
## Problem Description

The experimental vulnerability configuration seems wonky and has issues if you have multiple Dockerfiles opened.

## Proposed Solution

We incorrectly always included only one item in the response to `workspace/configuration` when we should be returning the same number of items that was sent in the request. The middleware has been corrected to return the same number of items as the request.

## Proof of Work

https://github.com/user-attachments/assets/5d81c4b2-9c7b-4d4a-a5fb-ad566ff4ea59