### PR TITLE
Record unrecognized errors when trying to start the language server

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,13 +116,19 @@ const activateDockerLSP = async (ctx: vscode.ExtensionContext) => {
                 error_function: 'DockerLanguageClient.start',
                 message: matches[0],
               });
+              return;
             }
           } else if (reject.code !== undefined) {
             queueTelemetryEvent('client_heartbeat', true, {
               error_function: 'DockerLanguageClient.start',
               message: String(reject.code),
             });
+            return;
           }
+          queueTelemetryEvent('client_heartbeat', true, {
+            error_function: 'DockerLanguageClient.start',
+            message: 'unrecognized',
+          });
         },
       );
   }


### PR DESCRIPTION
## Problem Description

With the latest changes, we only captured recognizable startup errors. We are still in the dark regarding other failure cases.

## Proposed Solution

Instead of simply recording recognized errors, we should also record unrecognized errors so we can become aware of error cases that we have not considered.

## Proof of Work

This is a data change that cannot be tested easily.