### PR TITLE
Check and try to make the language server binary executable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,11 @@ import {
   getNativeClient,
 } from './utils/lsp/lsp';
 import { DidChangeConfigurationNotification } from 'vscode-languageclient/node';
-import { publishTelemetry, queueTelemetryEvent } from './telemetry/client';
+import {
+  EVENT_CLIENT_HEARTBEAT,
+  publishTelemetry,
+  queueTelemetryEvent,
+} from './telemetry/client';
 import { checkForDockerEngine } from './utils/monitor';
 
 export const BakeBuildCommandId = 'dockerLspClient.bake.build';
@@ -112,13 +116,13 @@ const activateDockerLSP = async (ctx: vscode.ExtensionContext) => {
           if (typeof reject === 'string') {
             const matches = reject.match(errorRegExp);
             if (matches !== null && matches.length > 0) {
-              queueTelemetryEvent('client_heartbeat', true, {
+              queueTelemetryEvent(EVENT_CLIENT_HEARTBEAT, true, {
                 error_function: 'DockerLanguageClient.start',
                 message: matches[0],
               });
             }
           } else if (reject.code !== undefined) {
-            queueTelemetryEvent('client_heartbeat', true, {
+            queueTelemetryEvent(EVENT_CLIENT_HEARTBEAT, true, {
               error_function: 'DockerLanguageClient.start',
               message: String(reject.code),
             });
@@ -222,18 +226,18 @@ function recordVersionTelemetry() {
   });
   process.on('error', () => {
     // this happens if docker cannot be found on the PATH
-    queueTelemetryEvent('client_heartbeat', false, {
+    queueTelemetryEvent(EVENT_CLIENT_HEARTBEAT, false, {
       docker_version: 'spawn docker -v failed',
     });
     publishTelemetry();
   });
   process.on('exit', (code) => {
     if (code === 0) {
-      queueTelemetryEvent('client_heartbeat', false, {
+      queueTelemetryEvent(EVENT_CLIENT_HEARTBEAT, false, {
         docker_version: String(versionString),
       });
     } else {
-      queueTelemetryEvent('client_heartbeat', false, {
+      queueTelemetryEvent(EVENT_CLIENT_HEARTBEAT, false, {
         docker_version: String(code),
       });
     }

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -3,6 +3,8 @@ import * as process from 'process';
 import * as vscode from 'vscode';
 import { extensionVersion } from '../extension';
 
+export const EVENT_CLIENT_HEARTBEAT = 'client_heartbeat';
+
 interface TelemetryRecord {
   event: string;
   source: string;

--- a/src/utils/lsp/languageClient.ts
+++ b/src/utils/lsp/languageClient.ts
@@ -9,7 +9,10 @@ import {
 } from 'vscode-languageclient/node';
 import { BakeBuildCommandId } from '../../extension';
 import { getTelemetryValue } from './lsp';
-import { queueTelemetryEvent } from '../../telemetry/client';
+import {
+  EVENT_CLIENT_HEARTBEAT,
+  queueTelemetryEvent,
+} from '../../telemetry/client';
 
 export class DockerLanguageClient extends LanguageClient {
   protected fillInitializeParams(params: InitializeParams): void {
@@ -37,7 +40,7 @@ export class DockerLanguageClient extends LanguageClient {
     data?: any,
     showNotification?: boolean | 'force',
   ): void {
-    queueTelemetryEvent('client_heartbeat', true, {
+    queueTelemetryEvent(EVENT_CLIENT_HEARTBEAT, true, {
       message: filterMessage(message),
       error_function: 'DockerLanguageClient.error',
       show_notification: showNotification,
@@ -55,7 +58,7 @@ export class DockerLanguageClient extends LanguageClient {
       ): ErrorHandlerResult | Promise<ErrorHandlerResult> {
         const result: any = handler.error(error, message, count);
         if (result.action !== undefined) {
-          queueTelemetryEvent('client_heartbeat', true, {
+          queueTelemetryEvent(EVENT_CLIENT_HEARTBEAT, true, {
             error_function: 'ErrorHandler.error',
             count: count,
             action: result.action,
@@ -67,7 +70,7 @@ export class DockerLanguageClient extends LanguageClient {
       closed(): CloseHandlerResult | Promise<CloseHandlerResult> {
         const result: any = handler.closed();
         if (result.action !== undefined) {
-          queueTelemetryEvent('client_heartbeat', true, {
+          queueTelemetryEvent(EVENT_CLIENT_HEARTBEAT, true, {
             message: filterMessage(result.message),
             error_function: 'ErrorHandler.closed',
             action: result.action,


### PR DESCRIPTION
## Problem Description

The error data shows an `EACCES` for some users which may suggest that the binary is not executable. This may be because the file permissions has changed after the VSIX is extracted.

## Proposed Solution

We will try to resolve this by explicitly checking and making the binary executable first.

## Proof of Work

Verified by changing the binary on my own computer to `644` and the language server was still able to start.