### PR TITLE
Change the default telemetry setting value to a more ethical value 

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
             "error",
             "off"
           ],
-          "default": "all"
+          "default": "off"
         },
         "docker.lsp.debugServerPort": {
           "type": [


### PR DESCRIPTION
## Problem Description

The default value of telemetry is set to `all` in combination with an automatic installation of the extension.

## Proposed Solution

Change the default telemetry setting value to a more ethical value, since the extension was automatically installed to VS Code.