### PR TITLE
Support new Container Tools extension

### DIFF
--- a/build/downloader.mjs
+++ b/build/downloader.mjs
@@ -55,13 +55,13 @@ async function downloadLanguageServerBinary() {
     process.exit(1);
   }
 
-  const platform = process.platform;
+  const platform = process.platform === 'win32' ? 'windows' : process.platform;
   const arch = process.arch === 'x64' ? 'amd64' : 'arm64';
-  const suffix = platform === 'win32' ? '.exe' : '';
+  const suffix = platform === 'windows' ? '.exe' : '';
   const version = '0.3.5';
   const binaryFile = `docker-language-server-${platform}-${arch}-v${version}${suffix}`;
   const targetFile = `docker-language-server-${platform}-${arch}${suffix}`;
-  const url = `https://github.com/docker/docker-language-server/releases/download/v${version}/${binaryFile}${suffix}`;
+  const url = `https://github.com/docker/docker-language-server/releases/download/v${version}/${binaryFile}`;
   await run('bin', url, targetFile);
   fs.chmodSync(`bin/${targetFile}`, 0o755);
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "type": "git",
     "url": "https://github.com/docker/vscode-extension"
   },
-  "extensionDependencies": [
-    "ms-azuretools.vscode-docker"
-  ],
   "activationEvents": [
     "onLanguage:dockerbake",
     "onLanguage:dockercompose",
@@ -36,7 +33,7 @@
       {
         "title": "Scan for CVEs with Docker Scout",
         "command": "docker.scout.imageScan",
-        "enablement": "view == dockerImages && viewItem == image"
+        "enablement": "(view == dockerImages || view == vscode-containers.views.images) && viewItem == image"
       }
     ],
     "languages": [
@@ -59,7 +56,7 @@
       "view/item/context": [
         {
           "command": "docker.scout.imageScan",
-          "when": "view == dockerImages && viewItem == image",
+          "when": "(view == dockerImages || view == vscode-containers.views.images) && viewItem == image",
           "group": "images_group_dockerdx"
         }
       ]


### PR DESCRIPTION
## Problem Description

The new Container Tools extension will be releasing soon, and Docker DX should support it.

Fixes https://github.com/microsoft/vscode-containers/issues/38.

## Proposed Solution

1. Support the new Container Tools extension by adding its view ID as a location to show the Scout CVEs command
2. Remove `ms-azuretools.vscode-docker` as a dependency--we are going to do a slow rollout of Container Tools that will temporarily require users to uninstall vscode-docker; we don't want that to also uninstall Docker DX.
3. Fixes an issue in the language server downloader script on Windows

## Proof of Work

1. Verified that the Scout CVEs command shows up in the intended location in the Container Tools extension
2. Straightforward enough to not verify :smile:
3. `npm i` works well on Windows
