### PR TITLE
Make the Docker Desktop prompt configurable on the application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- set the Docker Desktop prompt setting correctly ([#90](https://github.com/docker/vscode-extension/issues/90))
+
 ## [0.4.9] - 2025-04-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
         "docker.extension.dockerEngineAvailabilityPrompt": {
           "type": "boolean",
           "description": "Be notified when Docker Engine is not available.",
-          "default": true
+          "default": true,
+          "scope": "application"
         },
         "docker.lsp.telemetry": {
           "type": "string",

--- a/src/utils/monitor.ts
+++ b/src/utils/monitor.ts
@@ -96,7 +96,11 @@ async function isDockerDesktopInstalled(): Promise<boolean> {
 function disableDockerEngineAvailabilityPrompt(): void {
   vscode.workspace
     .getConfiguration('docker.extension')
-    .set('dockerEngineAvailabilityPrompt', false);
+    .update(
+      'dockerEngineAvailabilityPrompt',
+      false,
+      vscode.ConfigurationTarget.Global,
+    );
 }
 
 /**


### PR DESCRIPTION
## Problem Description

The "Don't show again" button is not working correctly. It keeps prompting even if you click on the button. :(

## Proposed Solution

Changed the function call to update instead of set and also modified the setting so that it will only read and write it to a single place to keep things consistent.

Fixes #90.

## Proof of Work

I confirm that I tested this in the debugger and verified that the user's JSON settings file is getting updated accordingly.