### PR TITLE
Add support for generating VSIX builds for Alpine Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [linux, windows, darwin]
+        os: [alpine, linux, windows, darwin]
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -90,6 +90,9 @@ jobs:
           - os: linux
             nodeos: linux
             ext: ""
+          - os: linux
+            nodeos: alpine
+            ext: ""
 
     steps:
       - name: actions/checkout@v4 (docker/vscode-extension)
@@ -103,7 +106,7 @@ jobs:
 
       - working-directory: vscode-extension
         run: |
-          npm install
+          NODE_OS=${{ matrix.nodeos }} NODE_ARCH=${{ matrix.nodearch }} npm install
 
       - name: Set variables
         id: set-variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,14 +74,14 @@ jobs:
 
     strategy:
       matrix:
-        os: [alpine, linux, windows, darwin]
+        os: [alpine, linux, win32, darwin]
         arch: [amd64, arm64]
         include:
           - arch: amd64
             nodearch: x64
           - arch: arm64
             nodearch: arm64
-          - os: windows
+          - os: win32
             nodeos: win32
             ext: .exe
           - os: darwin
@@ -126,14 +126,14 @@ jobs:
         working-directory: vscode-extension
         run: |
           npm install -g @vscode/vsce
-          vsce package --target ${{ matrix.nodeos }}-${{ matrix.nodearch }} -o docker-vscode-extension-${{ matrix.nodeos }}-${{ matrix.nodearch }}-$VERSION-$SHA.vsix
+          vsce package --target ${{ matrix.os }}-${{ matrix.nodearch }} -o docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-$VERSION-$SHA.vsix
 
       - name: actions/upload-artifact@v4 (refs/heads)
         if: startsWith(github.ref, 'refs/heads')
         uses: actions/upload-artifact@v4
         with:
-          name: docker-vscode-extension-${{ matrix.nodeos }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}-${{ steps.set-variables.outputs.SHA }}.vsix
-          path: vscode-extension/docker-vscode-extension-${{ matrix.nodeos }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}-${{ steps.set-variables.outputs.SHA }}.vsix
+          name: docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}-${{ steps.set-variables.outputs.SHA }}.vsix
+          path: vscode-extension/docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}-${{ steps.set-variables.outputs.SHA }}.vsix
           if-no-files-found: error
 
       - name: Build the extension (refs/tags/v)
@@ -143,14 +143,14 @@ jobs:
         working-directory: vscode-extension
         run: |
           npm install -g @vscode/vsce
-          vsce package --target ${{ matrix.nodeos }}-${{ matrix.nodearch }} -o docker-vscode-extension-${{ matrix.nodeos }}-${{ matrix.nodearch }}-$VERSION.vsix
+          vsce package --target ${{ matrix.os }}-${{ matrix.nodearch }} -o docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-$VERSION.vsix
 
       - name: actions/upload-artifact@v4 (refs/tags/v)
         uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags/v')
         with:
-          name: docker-vscode-extension-${{ matrix.nodeos }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}.vsix
-          path: vscode-extension/docker-vscode-extension-${{ matrix.nodeos }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}.vsix
+          name: docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}.vsix
+          path: vscode-extension/docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}.vsix
           if-no-files-found: error
 
       - uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8 https://github.com/softprops/action-gh-release/commit/c062e08bd532815e2082a85e87e3ef29c3e6d191
@@ -158,4 +158,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: vscode-extension/docker-vscode-extension-${{ matrix.nodeos }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}.vsix
+          files: vscode-extension/docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}.vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,8 +90,8 @@ jobs:
           - os: linux
             nodeos: linux
             ext: ""
-          - os: linux
-            nodeos: alpine
+          - os: alpine
+            nodeos: linux
             ext: ""
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- add support for the `alpine-x64` and `alpine-arm64` targets
+
 ## [0.4.10] - 2025-04-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This extension currently supports the following operating systems and architectu
 | Windows          | `amd64`, `arm64` |
 | macOS            | `amd64`, `arm64` |
 | Linux            | `amd64`, `arm64` |
+| Alpine           | `amd64`, `arm64` |
 
 If you are on an unsupported system, let us know of your interest in this extension so we can prioritize the work accordingly.
 

--- a/build/downloader.mjs
+++ b/build/downloader.mjs
@@ -48,7 +48,10 @@ async function downloadSyntaxesFile() {
 }
 
 function getPlatform() {
-  const platform = process.env["NODE_OS"] === undefined ? process.platform : process.env["NODE_OS"];
+  const platform =
+    process.env['NODE_OS'] === undefined
+      ? process.platform
+      : process.env['NODE_OS'];
   if (platform === 'win32') {
     return 'windows';
   }
@@ -56,7 +59,10 @@ function getPlatform() {
 }
 
 function getArch() {
-  const arch = process.env["NODE_ARCH"] === undefined ? process.arch : process.env["NODE_ARCH"];
+  const arch =
+    process.env['NODE_ARCH'] === undefined
+      ? process.arch
+      : process.env['NODE_ARCH'];
   return arch === 'x64' ? 'amd64' : 'arm64';
 }
 

--- a/build/downloader.mjs
+++ b/build/downloader.mjs
@@ -47,6 +47,19 @@ async function downloadSyntaxesFile() {
   run('syntaxes', url, hclSyntaxFile);
 }
 
+function getPlatform() {
+  const platform = process.env["NODE_OS"] === undefined ? process.platform : process.env["NODE_OS"];
+  if (platform === 'win32') {
+    return 'windows';
+  }
+  return platform === 'alpine' ? 'linux' : platform;
+}
+
+function getArch() {
+  const arch = process.env["NODE_ARCH"] === undefined ? process.arch : process.env["NODE_ARCH"];
+  return arch === 'x64' ? 'amd64' : 'arm64';
+}
+
 async function downloadLanguageServerBinary() {
   if (process.arch !== 'x64' && process.arch !== 'arm64') {
     console.error(
@@ -55,8 +68,10 @@ async function downloadLanguageServerBinary() {
     process.exit(1);
   }
 
-  const platform = process.platform === 'win32' ? 'windows' : process.platform;
-  const arch = process.arch === 'x64' ? 'amd64' : 'arm64';
+  const platform = getPlatform();
+  const arch = getArch();
+  console.log(platform);
+  console.log(arch);
   const suffix = platform === 'windows' ? '.exe' : '';
   const version = '0.3.7';
   const binaryFile = `docker-language-server-${platform}-${arch}-v${version}${suffix}`;


### PR DESCRIPTION
## Problem Description

Although we create VSIX builds for `linux-x64` and `linux-arm64`, we do not currently generate builds for `alpine-x64` or `alpine-arm64`.

## Proposed Solution

The Docker Language Server binaries we are building are executable within Alpine Linux so it should be safe for us to generate VSIX builds for `alpine-x64` and `alpine-arm64`.

Closes #93.

## Proof of Work

To be verified...