### PR TITLE
CLI plugins error handling

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,8 +90,6 @@ function registerCommand(
 }
 
 const activateDockerLSP = async (ctx: vscode.ExtensionContext) => {
-  registerCommands(ctx);
-
   if (await activateDockerNativeLanguageClient(ctx)) {
     getNativeClient()
       .start()
@@ -126,6 +124,7 @@ const activateDockerLSP = async (ctx: vscode.ExtensionContext) => {
 export function activate(ctx: vscode.ExtensionContext) {
   extensionVersion = String(ctx.extension.packageJSON.version);
   recordVersionTelemetry();
+  registerCommands(ctx);
   activateExtension(ctx);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import {
 } from './telemetry/client';
 import { checkForDockerEngine } from './utils/monitor';
 import { spawnDockerCommand } from './utils/spawnDockerCommand';
+import { getExtensionSetting } from './utils/settings';
 
 export const BakeBuildCommandId = 'dockerLspClient.bake.build';
 export const ScoutImageScanCommandId = 'docker.scout.imageScan';
@@ -129,11 +130,7 @@ export function activate(ctx: vscode.ExtensionContext) {
 }
 
 async function activateExtension(ctx: vscode.ExtensionContext) {
-  if (
-    vscode.workspace
-      .getConfiguration('docker.extension')
-      .get('dockerEngineAvailabilityPrompt')
-  ) {
+  if (getExtensionSetting('dockerEngineAvailabilityPrompt')) {
     let notified = false;
     for (const document of vscode.workspace.textDocuments) {
       if (

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import {
   queueTelemetryEvent,
 } from './telemetry/client';
 import { checkForDockerEngine } from './utils/monitor';
+import { spawnDockerCommand } from './utils/spawnDockerCommand';
 
 export const BakeBuildCommandId = 'dockerLspClient.bake.build';
 export const ScoutImageScanCommandId = 'docker.scout.imageScan';
@@ -22,15 +23,7 @@ const errorRegExp = new RegExp('(E[A-Z]+)');
 
 function registerCommands(ctx: vscode.ExtensionContext) {
   registerCommand(ctx, BakeBuildCommandId, async (commandArgs: any) => {
-    const result = await new Promise<boolean>((resolve) => {
-      const process = spawn('docker', ['buildx', 'bake', '--help']);
-      process.on('error', () => {
-        resolve(false);
-      });
-      process.on('exit', (code) => {
-        resolve(code === 0);
-      });
-    });
+    const result = await spawnDockerCommand('buildx', ['bake', '--help']);
     const args = ['buildx', 'bake'];
 
     if (commandArgs['call'] === 'print') {
@@ -56,15 +49,7 @@ function registerCommands(ctx: vscode.ExtensionContext) {
   });
 
   registerCommand(ctx, ScoutImageScanCommandId, async (args) => {
-    const result = await new Promise<boolean>((resolve) => {
-      const process = spawn('docker', ['scout']);
-      process.on('error', () => {
-        resolve(false);
-      });
-      process.on('exit', (code) => {
-        resolve(code === 0);
-      });
-    });
+    const result = spawnDockerCommand('scout');
     const options: vscode.ShellExecutionOptions = {};
     if (
       vscode.workspace.workspaceFolders === undefined ||

--- a/src/utils/monitor.ts
+++ b/src/utils/monitor.ts
@@ -1,6 +1,5 @@
 import { access } from 'fs';
 import { spawn } from 'child_process';
-import * as vscode from 'vscode';
 import { spawnDockerCommand } from './spawnDockerCommand';
 import {
   promptOpenDockerDesktop,
@@ -8,6 +7,7 @@ import {
   promptUnauthenticatedDesktop,
 } from './prompt';
 import { getDockerDesktopPath } from './os';
+import { getExtensionSetting } from './settings';
 
 enum DockerEngineStatus {
   Unavailable,
@@ -20,11 +20,7 @@ enum DockerEngineStatus {
  * either install or open Docker Desktop.
  */
 export async function checkForDockerEngine(): Promise<void> {
-  if (
-    !vscode.workspace
-      .getConfiguration('docker.extension')
-      .get('dockerEngineAvailabilityPrompt')
-  ) {
+  if (!getExtensionSetting('dockerEngineAvailabilityPrompt')) {
     return;
   }
 

--- a/src/utils/monitor.ts
+++ b/src/utils/monitor.ts
@@ -149,7 +149,7 @@ async function promptOpenDockerDesktop(): Promise<void> {
  */
 async function promptInstallDesktop(): Promise<void> {
   const response = await vscode.window.showInformationMessage(
-    'Docker is not running. To get help with your Dockerfile, start Docker.',
+    'Docker is not running. To get help with your Dockerfile, install Docker.',
     "Don't show again",
     'Install Docker Desktop',
   );

--- a/src/utils/monitor.ts
+++ b/src/utils/monitor.ts
@@ -1,6 +1,7 @@
 import { access } from 'fs';
 import { spawn } from 'child_process';
 import * as vscode from 'vscode';
+import { spawnDockerCommand } from './spawnDockerCommand';
 
 enum DockerEngineStatus {
   Unavailable,
@@ -76,16 +77,7 @@ function getDockerDesktopPath(): string {
 
 async function isDockerDesktopInstalled(): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
-    const s = spawn('docker', ['desktop', 'version']);
-    s.on('error', () => {
-      // this happens if docker cannot be found on the PATH
-      resolve(false);
-    });
-    s.on('exit', (code) => {
-      if (code === 0) {
-        return resolve(true);
-      }
-
+    spawnDockerCommand('docker', ['desktop', 'version'], () => {
       access(getDockerDesktopPath(), (err) => {
         resolve(err === null);
       });

--- a/src/utils/monitor.ts
+++ b/src/utils/monitor.ts
@@ -1,12 +1,10 @@
-import { access } from 'fs';
 import { spawn } from 'child_process';
-import { spawnDockerCommand } from './spawnDockerCommand';
 import {
   promptOpenDockerDesktop,
   promptInstallDesktop,
   promptUnauthenticatedDesktop,
 } from './prompt';
-import { getDockerDesktopPath } from './os';
+import { isDockerDesktopInstalled } from './os';
 import { getExtensionSetting } from './settings';
 
 enum DockerEngineStatus {
@@ -63,16 +61,6 @@ function checkDockerStatus(): Promise<DockerEngineStatus> {
         return resolve(DockerEngineStatus.Unauthenticated);
       }
       return resolve(DockerEngineStatus.Unavailable);
-    });
-  });
-}
-
-async function isDockerDesktopInstalled(): Promise<boolean> {
-  return new Promise<boolean>((resolve) => {
-    spawnDockerCommand('docker', ['desktop', 'version'], () => {
-      access(getDockerDesktopPath(), (err) => {
-        resolve(err === null);
-      });
     });
   });
 }

--- a/src/utils/os.ts
+++ b/src/utils/os.ts
@@ -13,10 +13,16 @@ export function getDockerDesktopPath(): string {
 
 export async function isDockerDesktopInstalled(): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
-    spawnDockerCommand('docker', ['desktop', 'version'], () => {
-      access(getDockerDesktopPath(), (err) => {
-        resolve(err === null);
-      });
+    spawnDockerCommand('docker', ['desktop', 'version'], {
+      onExit: (code) => {
+        if (code === 0) {
+          return resolve(true);
+        }
+
+        access(getDockerDesktopPath(), (err) => {
+          resolve(err === null);
+        });
+      },
     });
   });
 }

--- a/src/utils/os.ts
+++ b/src/utils/os.ts
@@ -1,0 +1,9 @@
+export function getDockerDesktopPath(): string {
+  switch (process.platform) {
+    case 'win32':
+      return 'C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe';
+    case 'darwin':
+      return '/Applications/Docker.app';
+  }
+  return '/opt/docker-desktop/bin/com.docker.backend';
+}

--- a/src/utils/os.ts
+++ b/src/utils/os.ts
@@ -1,3 +1,6 @@
+import { access } from 'fs';
+import { spawnDockerCommand } from './spawnDockerCommand';
+
 export function getDockerDesktopPath(): string {
   switch (process.platform) {
     case 'win32':
@@ -6,4 +9,14 @@ export function getDockerDesktopPath(): string {
       return '/Applications/Docker.app';
   }
   return '/opt/docker-desktop/bin/com.docker.backend';
+}
+
+export async function isDockerDesktopInstalled(): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    spawnDockerCommand('docker', ['desktop', 'version'], () => {
+      access(getDockerDesktopPath(), (err) => {
+        resolve(err === null);
+      });
+    });
+  });
 }

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,0 +1,71 @@
+import * as vscode from 'vscode';
+import { spawn } from 'child_process';
+import { disableDockerEngineAvailabilityPrompt } from './settings';
+import { getDockerDesktopPath } from './os';
+
+/**
+ * Prompts the user to login to Docker Desktop.
+ */
+export async function promptUnauthenticatedDesktop(): Promise<void> {
+  const response = await vscode.window.showInformationMessage(
+    'Docker is not running. To get help with your Dockerfile, sign in to Docker Desktop.',
+    "Don't show again",
+  );
+  if (response === "Don't show again") {
+    disableDockerEngineAvailabilityPrompt();
+  }
+}
+
+/**
+ * Prompts the user to open Docker Desktop.
+ */
+export async function promptOpenDockerDesktop(): Promise<void> {
+  const response = await vscode.window.showInformationMessage(
+    'Docker is not running. To get help with your Dockerfile, start Docker.',
+    "Don't show again",
+    'Open Docker Desktop',
+  );
+  if (response === "Don't show again") {
+    disableDockerEngineAvailabilityPrompt();
+  } else if (response === 'Open Docker Desktop') {
+    const dockerDesktopPath = getDockerDesktopPath();
+    if (process.platform === 'darwin') {
+      spawn('open', [dockerDesktopPath]).on('exit', (code) => {
+        if (code !== 0) {
+          vscode.window.showErrorMessage(
+            `Failed to open Docker Desktop: open ${dockerDesktopPath}`,
+            { modal: true },
+          );
+        }
+      });
+    } else {
+      spawn(dockerDesktopPath).on('exit', (code) => {
+        if (code !== 0) {
+          vscode.window.showErrorMessage(
+            `Failed to open Docker Desktop: ${dockerDesktopPath}`,
+            { modal: true },
+          );
+        }
+      });
+    }
+  }
+}
+
+/**
+ * Prompts the user to install Docker Desktop by navigating to the
+ * website.
+ */
+export async function promptInstallDesktop(): Promise<void> {
+  const response = await vscode.window.showInformationMessage(
+    'Docker is not running. To get help with your Dockerfile, install Docker.',
+    "Don't show again",
+    'Install Docker Desktop',
+  );
+  if (response === "Don't show again") {
+    disableDockerEngineAvailabilityPrompt();
+  } else if (response === 'Install Docker Desktop') {
+    vscode.env.openExternal(
+      vscode.Uri.parse('https://docs.docker.com/install/'),
+    );
+  }
+}

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -69,3 +69,15 @@ export async function promptInstallDesktop(): Promise<void> {
     );
   }
 }
+
+/**
+ * Shows a message to the user indicating that Docker Desktop does not know the command
+ */
+export async function showUnknownCommandMessage(
+  command: string,
+): Promise<void> {
+  // TODO: Get a proper error message from Allie
+  await vscode.window.showErrorMessage(
+    `Docker Desktop does not know the command "${command}".`,
+  );
+}

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 
+type DockerExtensionSettings = 'dockerEngineAvailabilityPrompt';
+
 /**
  * Retrieves the value of a specified setting from the Docker extension's configuration.
  *
@@ -7,7 +9,7 @@ import * as vscode from 'vscode';
  * @returns The value of the specified setting, or `undefined` if the setting is not found.
  */
 
-export function getExtensionSetting(setting: string) {
+export function getExtensionSetting(setting: DockerExtensionSettings) {
   return vscode.workspace.getConfiguration('docker.extension').get(setting);
 }
 

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+export function disableDockerEngineAvailabilityPrompt(): void {
+  vscode.workspace
+    .getConfiguration('docker.extension')
+    .update(
+      'dockerEngineAvailabilityPrompt',
+      false,
+      vscode.ConfigurationTarget.Global,
+    );
+}

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,11 +1,33 @@
 import * as vscode from 'vscode';
 
-export function disableDockerEngineAvailabilityPrompt(): void {
+/**
+ * Retrieves the value of a specified setting from the Docker extension's configuration.
+ *
+ * @param setting - The name of the setting to retrieve.
+ * @returns The value of the specified setting, or `undefined` if the setting is not found.
+ */
+
+export function getExtensionSetting(setting: string) {
+  return vscode.workspace.getConfiguration('docker.extension').get(setting);
+}
+
+/**
+ * Updates the value of a specified setting in the Docker extension's configuration.
+ *
+ * @param setting - The name of the setting to update.
+ * @param value - The new value to set for the specified setting.
+ */
+function setExtensionSetting(
+  setting: string,
+  value: string | boolean,
+  configurationTarget: vscode.ConfigurationTarget = vscode.ConfigurationTarget
+    .Global,
+): void {
   vscode.workspace
     .getConfiguration('docker.extension')
-    .update(
-      'dockerEngineAvailabilityPrompt',
-      false,
-      vscode.ConfigurationTarget.Global,
-    );
+    .update(setting, value, configurationTarget);
+}
+
+export function disableDockerEngineAvailabilityPrompt(): void {
+  setExtensionSetting('dockerEngineAvailabilityPrompt', false);
 }

--- a/src/utils/spawnDockerCommand.ts
+++ b/src/utils/spawnDockerCommand.ts
@@ -3,8 +3,11 @@
  *
  * @param command - The Docker command to execute (e.g., "run", "build").
  * @param args - An optional array of arguments to pass to the Docker command.
- * @param onExit - An optional callback function that is invoked when the process exits with a non-zero code.
- * @param onStderr - An optional callback function that is invoked when there is data written to the standard error stream.
+ * @param processEvents - An object containing optional callback functions for handling process events:
+ *   - onExit: Invoked when the process exits with the exit code.
+ *   - onError: Invoked when an error occurs during process execution.
+ *   - onStdout: Invoked when there is data written to the standard output stream.
+ *   - onStderr: Invoked when there is data written to the standard error stream.
  * @returns A promise that resolves to `true` if the command exits with a code of 0, or `false` otherwise.
  */
 import { spawn } from 'child_process';
@@ -12,29 +15,39 @@ import { spawn } from 'child_process';
 export async function spawnDockerCommand(
   command: string,
   args: string[] = [],
-  onExit?: () => void,
-  onStderr?: () => void,
+  processEvents: {
+    onExit?: (code: number | null) => void;
+    onError?: (error: Error) => void;
+    onStderr?: (chunk: any) => void;
+    onStdout?: (chunk: any) => void;
+  } = {},
 ) {
   return await new Promise<boolean>((resolve) => {
+    const { onExit, onError, onStdout, onStderr } = processEvents;
     const process = spawn('docker', [command, ...args]);
-    process.on('error', () => {
-      // TODO: Show error prompt
-      resolve(false);
-    });
-    process.stderr.on('data', () => {
-      if (onStderr) {
-        onStderr();
+    process.on('error', (error) => {
+      if (onError) {
+        onError(error);
       }
+      resolve(false);
     });
     process.on('exit', (code) => {
-      if (code === 0) {
-        return resolve(true);
-      }
-
       if (onExit) {
-        onExit();
+        onExit(code);
       }
-      resolve(false);
+      resolve(code === 0);
     });
+
+    if (onStderr) {
+      process.stderr.on('data', (chunk) => {
+        onStderr(chunk);
+      });
+    }
+
+    if (onStdout) {
+      process.stdout.on('data', (chunk) => {
+        onStdout(chunk);
+      });
+    }
   });
 }

--- a/src/utils/spawnDockerCommand.ts
+++ b/src/utils/spawnDockerCommand.ts
@@ -1,0 +1,13 @@
+import { spawn } from 'child_process';
+
+export async function spawnDockerCommand(command: string, args: string[] = []) {
+  return await new Promise<boolean>((resolve) => {
+    const process = spawn('docker', [command, ...args]);
+    process.on('error', () => {
+      resolve(false);
+    });
+    process.on('exit', (code) => {
+      resolve(code === 0);
+    });
+  });
+}

--- a/src/utils/spawnDockerCommand.ts
+++ b/src/utils/spawnDockerCommand.ts
@@ -1,13 +1,24 @@
 import { spawn } from 'child_process';
 
-export async function spawnDockerCommand(command: string, args: string[] = []) {
+export async function spawnDockerCommand(
+  command: string,
+  args: string[] = [],
+  onExit?: () => void,
+) {
   return await new Promise<boolean>((resolve) => {
     const process = spawn('docker', [command, ...args]);
     process.on('error', () => {
       resolve(false);
     });
     process.on('exit', (code) => {
-      resolve(code === 0);
+      if (code === 0) {
+        return resolve(true);
+      }
+
+      if (onExit) {
+        onExit();
+      }
+      resolve(false);
     });
   });
 }

--- a/src/utils/spawnDockerCommand.ts
+++ b/src/utils/spawnDockerCommand.ts
@@ -11,6 +11,7 @@
  * @returns A promise that resolves to `true` if the command exits with a code of 0, or `false` otherwise.
  */
 import { spawn } from 'child_process';
+import { showUnknownCommandMessage } from './prompt';
 
 export async function spawnDockerCommand(
   command: string,
@@ -38,11 +39,14 @@ export async function spawnDockerCommand(
       resolve(code === 0);
     });
 
-    if (onStderr) {
-      process.stderr.on('data', (chunk) => {
+    process.stderr.on('data', (chunk: string) => {
+      if (chunk.includes('docker: unknown command')) {
+        showUnknownCommandMessage(command);
+      }
+      if (onStderr) {
         onStderr(chunk);
-      });
-    }
+      }
+    });
 
     if (onStdout) {
       process.stdout.on('data', (chunk) => {

--- a/src/utils/spawnDockerCommand.ts
+++ b/src/utils/spawnDockerCommand.ts
@@ -12,6 +12,7 @@
  */
 import { spawn } from 'child_process';
 import { showUnknownCommandMessage } from './prompt';
+import { getExtensionSetting } from './settings';
 
 export async function spawnDockerCommand(
   command: string,
@@ -40,7 +41,10 @@ export async function spawnDockerCommand(
     });
 
     process.stderr.on('data', (chunk: string) => {
-      if (chunk.includes('docker: unknown command')) {
+      if (
+        chunk.includes('docker: unknown command') &&
+        getExtensionSetting('dockerEngineAvailabilityPrompt')
+      ) {
         showUnknownCommandMessage(command);
       }
       if (onStderr) {

--- a/src/utils/spawnDockerCommand.ts
+++ b/src/utils/spawnDockerCommand.ts
@@ -1,14 +1,30 @@
+/**
+ * Spawns a Docker command as a child process and handles its execution.
+ *
+ * @param command - The Docker command to execute (e.g., "run", "build").
+ * @param args - An optional array of arguments to pass to the Docker command.
+ * @param onExit - An optional callback function that is invoked when the process exits with a non-zero code.
+ * @param onStderr - An optional callback function that is invoked when there is data written to the standard error stream.
+ * @returns A promise that resolves to `true` if the command exits with a code of 0, or `false` otherwise.
+ */
 import { spawn } from 'child_process';
 
 export async function spawnDockerCommand(
   command: string,
   args: string[] = [],
   onExit?: () => void,
+  onStderr?: () => void,
 ) {
   return await new Promise<boolean>((resolve) => {
     const process = spawn('docker', [command, ...args]);
     process.on('error', () => {
+      // TODO: Show error prompt
       resolve(false);
+    });
+    process.stderr.on('data', () => {
+      if (onStderr) {
+        onStderr();
+      }
     });
     process.on('exit', (code) => {
       if (code === 0) {


### PR DESCRIPTION
## Problem Description

If a user has an old version of docker that does not include e.g. `docker scout` or `docker ai` commands and the extension relies on them, we just error out "silently" in the console.

<!--
Include a description of the problem being solved here or a link to the original issue in GitHub and/or Jira.
-->

## Proposed Solution

This PR introduces an error message being shown when a particular sub command of docker is not available.

<!--
How does the change resolve the issue at hand?
-->

## Proof of Work

TBD once we get a correct error message
