### PR TITLE
Check for Docker Desktop correctly

### DIFF
--- a/src/utils/os.ts
+++ b/src/utils/os.ts
@@ -13,7 +13,9 @@ export function getDockerDesktopPath(): string {
 
 export async function isDockerDesktopInstalled(): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
-    spawnDockerCommand('docker', ['desktop', 'version'], {
+    spawnDockerCommand('desktop', ['version'], {
+      onError: () => resolve(false),
+
       onExit: (code) => {
         if (code === 0) {
           return resolve(true);


### PR DESCRIPTION
## Problem Description

The Docker Desktop check is not being executed correctly. It's running `docker docker desktop version` now.

## Proposed Solution

When the code was refactored to use a generic `spawnDockerCommand` function, the removal of `'docker'` was missed so we were no longer running `docker desktop version` correctly. We also need to use the `onError` function to ensure that the code is executed correctly in the event that the docker binary cannot be found.

## Proof of Work

Verified that the code is working in a debugger.