### PR TITLE
Prompt the user to install Docker Desktop if Scout is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- tagged appropriate settings to make them easier to search for
+- suggest the user install Docker Desktop if Scout cannot be found
+
 ## [0.6.0] - 2025-04-29
 
 ### Added

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,11 @@ const errorRegExp = new RegExp('(E[A-Z]+)');
 
 function registerCommands(ctx: vscode.ExtensionContext) {
   registerCommand(ctx, BakeBuildCommandId, async (commandArgs: any) => {
-    const result = await spawnDockerCommand('buildx', ['bake', '--help']);
+    const result = await spawnDockerCommand(
+      'buildx',
+      ['bake', '--help'],
+      "Bake is not available. To access Docker Bake's features, install Docker Desktop.",
+    );
     const args = ['buildx', 'bake'];
 
     if (commandArgs['call'] === 'print') {
@@ -50,7 +54,11 @@ function registerCommands(ctx: vscode.ExtensionContext) {
   });
 
   registerCommand(ctx, ScoutImageScanCommandId, async (args) => {
-    const result = spawnDockerCommand('scout');
+    const result = spawnDockerCommand(
+      'scout',
+      [],
+      "Docker Scout is not available. To access Docker Scout's features, install Docker Desktop.",
+    );
     const options: vscode.ShellExecutionOptions = {};
     if (
       vscode.workspace.workspaceFolders === undefined ||

--- a/src/utils/monitor.ts
+++ b/src/utils/monitor.ts
@@ -40,7 +40,7 @@ export async function checkForDockerEngine(): Promise<void> {
 function checkDockerStatus(): Promise<DockerEngineStatus> {
   return new Promise<DockerEngineStatus>((resolve) => {
     let output = '';
-    spawnDockerCommand('ps', [], {
+    spawnDockerCommand('ps', [], undefined, {
       onError: () => resolve(DockerEngineStatus.Unavailable),
       onStderr: (chunk) => {
         output += String(chunk);

--- a/src/utils/os.ts
+++ b/src/utils/os.ts
@@ -13,7 +13,7 @@ export function getDockerDesktopPath(): string {
 
 export async function isDockerDesktopInstalled(): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
-    spawnDockerCommand('desktop', ['version'], {
+    spawnDockerCommand('desktop', ['version'], undefined, {
       onError: () => resolve(false),
 
       onExit: (code) => {

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -55,9 +55,11 @@ export async function promptOpenDockerDesktop(): Promise<void> {
  * Prompts the user to install Docker Desktop by navigating to the
  * website.
  */
-export async function promptInstallDesktop(): Promise<void> {
+export async function promptInstallDesktop(
+  message: string = 'Docker is not running. To get help with your Dockerfile, install Docker.',
+): Promise<void> {
   const response = await vscode.window.showInformationMessage(
-    'Docker is not running. To get help with your Dockerfile, install Docker.',
+    message,
     "Don't show again",
     'Install Docker Desktop',
   );
@@ -68,16 +70,4 @@ export async function promptInstallDesktop(): Promise<void> {
       vscode.Uri.parse('https://docs.docker.com/install/'),
     );
   }
-}
-
-/**
- * Shows a message to the user indicating that Docker Desktop does not know the command
- */
-export async function showUnknownCommandMessage(
-  command: string,
-): Promise<void> {
-  // TODO: Get a proper error message from Allie
-  await vscode.window.showErrorMessage(
-    `Docker Desktop does not know the command "${command}".`,
-  );
 }

--- a/src/utils/spawnDockerCommand.ts
+++ b/src/utils/spawnDockerCommand.ts
@@ -11,12 +11,13 @@
  * @returns A promise that resolves to `true` if the command exits with a code of 0, or `false` otherwise.
  */
 import { spawn } from 'child_process';
-import { showUnknownCommandMessage } from './prompt';
+import { promptInstallDesktop } from './prompt';
 import { getExtensionSetting } from './settings';
 
 export async function spawnDockerCommand(
   command: string,
   args: string[] = [],
+  message?: string,
   processEvents: {
     onExit?: (code: number | null) => void;
     onError?: (error: Error) => void;
@@ -45,7 +46,7 @@ export async function spawnDockerCommand(
         chunk.includes('docker: unknown command') &&
         getExtensionSetting('dockerEngineAvailabilityPrompt')
       ) {
-        showUnknownCommandMessage(command);
+        promptInstallDesktop(message);
       }
       if (onStderr) {
         onStderr(chunk);


### PR DESCRIPTION
## Problem Description

If Scout is not available, users cannot use the "Scan for CVEs with Docker Scout" command.

## Proposed Solution

If Scout is not available, we will suggest the user install Docker Desktop so that the Scout CLI plugin will get installed.

## Proof of Work

![image](https://github.com/user-attachments/assets/bf1f377d-06b6-4f6a-9796-f55d42fdaf44)