### PR TITLE
Record if certain extensions are installed

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -23,6 +23,10 @@ If you have already opted out of sending telemetry in Visual Studio Code then no
 - Docker version
 - function names and parameters for diagnosing errors and crashes
 - error messages when the language server is unable to start or is crashing
+- if certain extensions are also installed
+    - [Microsoft's Container Tools extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-containers)
+    - [Microsoft's Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
+    - [Red Hat's YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
 
 The list above does _not_ include any telemetry collected by the [Docker Language Server](https://github.com/docker/docker-language-server). For telemetry collected by the Docker Language Server, please refer to the telemetry documentation of that project.
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -24,9 +24,9 @@ If you have already opted out of sending telemetry in Visual Studio Code then no
 - function names and parameters for diagnosing errors and crashes
 - error messages when the language server is unable to start or is crashing
 - if certain extensions are also installed
-    - [Microsoft's Container Tools extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-containers)
-    - [Microsoft's Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
-    - [Red Hat's YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+  - [Microsoft's Container Tools extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-containers)
+  - [Microsoft's Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
+  - [Red Hat's YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
 
 The list above does _not_ include any telemetry collected by the [Docker Language Server](https://github.com/docker/docker-language-server). For telemetry collected by the Docker Language Server, please refer to the telemetry documentation of that project.
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,6 +211,15 @@ function listenForConfigurationChanges(ctx: vscode.ExtensionContext) {
 }
 
 function recordVersionTelemetry() {
+  const installedExtensions = vscode.extensions.all
+    .filter((extension) => {
+      return (
+        extension.id === 'ms-azuretools.vscode-docker' ||
+        extension.id === 'ms-azuretools.vscode-containers' ||
+        extension.id === 'redhat.vscode-yaml'
+      );
+    })
+    .map((extension) => extension.id);
   let versionString: string | null = null;
   const process = spawn('docker', ['-v']);
   process.stdout.on('data', (data) => {
@@ -223,6 +232,7 @@ function recordVersionTelemetry() {
     // this happens if docker cannot be found on the PATH
     queueTelemetryEvent(EVENT_CLIENT_HEARTBEAT, false, {
       docker_version: 'spawn docker -v failed',
+      installedExtensions,
     });
     publishTelemetry();
   });
@@ -230,10 +240,12 @@ function recordVersionTelemetry() {
     if (code === 0) {
       queueTelemetryEvent(EVENT_CLIENT_HEARTBEAT, false, {
         docker_version: String(versionString),
+        installedExtensions,
       });
     } else {
       queueTelemetryEvent(EVENT_CLIENT_HEARTBEAT, false, {
         docker_version: String(code),
+        installedExtensions,
       });
     }
     publishTelemetry();

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -9,7 +9,7 @@ interface TelemetryRecord {
   event: string;
   source: string;
   event_timestamp: number;
-  properties: { [key: string]: boolean | number | string | undefined };
+  properties: { [key: string]: boolean | number | string | object | undefined };
 }
 
 const events: TelemetryRecord[] = [];
@@ -17,7 +17,7 @@ const events: TelemetryRecord[] = [];
 export function queueTelemetryEvent(
   event: string,
   error: boolean,
-  properties: { [key: string]: boolean | number | string | undefined },
+  properties: { [key: string]: boolean | number | string | object | undefined },
 ) {
   if (!vscode.env.isTelemetryEnabled) {
     return;


### PR DESCRIPTION
## Problem Description

The Visual Studio Code Marketplace is huge and different extensions offer different things. If multiple extensions offer the same features, then users may get duplicated results for hover tooltips or code completion suggestions.

## Proposed Solution

As this extension has overlapping features with Microsoft's extensions and Red Hat's extension, knowing how often we are installed alongside these other extensions will help us understand usage patterns and how best to deduplicate similar features and educate users as to _why_ they are seeing duplicated results.

## Proof of Work

I've verified the payload in the debugger.