### PR TITLE
Prompt the user about duplicated Compose features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Docker DX extension will be documented in this file.
 
 - tagged appropriate settings to make them easier to search for
 - suggest the user install Docker Desktop if Scout cannot be found
+- prompt the user about duplicated Compose features if Red Hat's YAML extension is also installed
 
 ## [0.6.0] - 2025-04-29
 

--- a/README.md
+++ b/README.md
@@ -89,15 +89,15 @@ Do you have any of the following extensions installed?
   1. To disable duplicates from this extension, create a JSON file with `{}` as its content and save it somewhere. Let's say it is at `/home/user/empty.json`.
   2. Open the [Command Palette](https://code.visualstudio.com/api/ux-guidelines/command-palette) in Visual Studio Code and open "Preferences: Open User Settings (JSON)".
   3. Create an object attribute for `yaml.schemas` if it does not already exist.
-  4. Inside the `yaml.schemas` object, map your empty JSON file to Compose YAML files.
-
+  4. Inside the `yaml.schemas` object, map your empty JSON file to Compose YAML files by following the snippet below.
+  5. YAML files named `compose*y*ml` or `docker-compose*y*ml` will now no longer have the Compose schema associated with them in Red Hat's extension so Red Hat's extension will stop providing YAML features for Compose files. This admittedly is a strange way to disable YAML features for a given file but it is the only known workaround for resolving this until [redhat-developer/vscode-yaml#1088](https://github.com/redhat-developer/vscode-yaml/issues/1088) is implemented.
 ```JSONC
 {
   "yaml.schemas": {
     // this tells Red Hat's YAML extension to consider Compose YAML
     // files as not having a schema so it will stop suggesting code
     // completion items, hover tooltips, and so on
-    "/home/user/empty.json": ["compose*y*ml*", "docker-compose*y*ml*"]
+    "/home/user/empty.json": ["compose*y*ml", "docker-compose*y*ml"]
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -79,6 +79,12 @@
           "default": true,
           "scope": "application"
         },
+        "docker.extension.yamlDuplicationPrompt": {
+          "type": "boolean",
+          "description": "Determines if the user should be prompted about duplicated Compose support due to having Red Hat's YAML extension installed.",
+          "default": true,
+          "scope": "application"
+        },
         "docker.lsp.telemetry": {
           "type": "string",
           "description": "Determines what telemetry is collected by Docker. If vscode.env.isTelemetryEnabled is false, then telemetry collection is disabled regardless of what has been set for this configuration value.",

--- a/src/utils/monitor.ts
+++ b/src/utils/monitor.ts
@@ -1,16 +1,64 @@
+import * as vscode from 'vscode';
 import {
   promptOpenDockerDesktop,
   promptInstallDesktop,
   promptUnauthenticatedDesktop,
 } from './prompt';
-import { isDockerDesktopInstalled } from './os';
-import { getExtensionSetting } from './settings';
+import { createEmptyComposeSchemaFile, isDockerDesktopInstalled } from './os';
+import { disableYamlDuplicationPrompt, getExtensionSetting } from './settings';
 import { spawnDockerCommand } from './spawnDockerCommand';
 
 enum DockerEngineStatus {
   Unavailable,
   Unauthenticated,
   Available,
+}
+
+/**
+ * Prompt the user about duplicated YAML editing features caused by
+ * having both the Docker DX extension and Red Hat's YAML extension
+ * installed.
+ */
+export async function promptComposeDuplications(): Promise<void> {
+  const emptyComposeSchemaFile = await createEmptyComposeSchemaFile();
+  const config = vscode.workspace.getConfiguration('yaml');
+  const schemas = config.get<object>('schemas');
+  if (schemas !== undefined) {
+    for (const schema of Object.keys(schemas)) {
+      if (schema === emptyComposeSchemaFile.path) {
+        // the empty file is already being used by yaml.schemas, do not need to prompt
+        return;
+      }
+    }
+  }
+
+  const response = await vscode.window.showWarningMessage(
+    'Both the Docker DX and Red Hat YAML extensions are providing editor features for your Compose files which may result in duplicate hovers and code completion suggestions. ' +
+      'Would you like to globally disable Compose support in the Red Hat YAML extension?',
+    'Disable',
+    'Details',
+    "Don't show me again",
+  );
+  if (response === 'Disable') {
+    config.update(
+      'schemas',
+      {
+        [emptyComposeSchemaFile.path]: ['compose*y*ml', 'docker-compose*y*ml'],
+      },
+      vscode.ConfigurationTarget.Global,
+    );
+    vscode.window.showInformationMessage(
+      'The global yaml.schemas setting has been updated.',
+    );
+  } else if (response === 'Details') {
+    vscode.env.openExternal(
+      vscode.Uri.parse(
+        'https://github.com/docker/vscode-extension/blob/main/README.md#faq',
+      ),
+    );
+  } else if (response === "Don't show me again") {
+    disableYamlDuplicationPrompt();
+  }
 }
 
 /**

--- a/src/utils/os.ts
+++ b/src/utils/os.ts
@@ -1,5 +1,7 @@
+import * as vscode from 'vscode';
 import { access } from 'fs';
 import { spawnDockerCommand } from './spawnDockerCommand';
+import { globalStorageUri } from '../extension';
 
 export function getDockerDesktopPath(): string {
   switch (process.platform) {
@@ -27,4 +29,23 @@ export async function isDockerDesktopInstalled(): Promise<boolean> {
       },
     });
   });
+}
+
+/**
+ * Creates an empty JSON schema file (with the content "{}", an empty
+ * dictionary) in the global storage location of the Docker DX
+ * extension. The file will be named empty.json.
+ */
+export async function createEmptyComposeSchemaFile(): Promise<vscode.Uri> {
+  await vscode.workspace.fs.createDirectory(globalStorageUri);
+  const emptyComposeSchemaFile = vscode.Uri.joinPath(
+    globalStorageUri,
+    'compose',
+    'empty.json',
+  );
+  await vscode.workspace.fs.writeFile(
+    emptyComposeSchemaFile,
+    Buffer.from('{}'),
+  );
+  return emptyComposeSchemaFile;
 }

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 
-type DockerExtensionSettings = 'dockerEngineAvailabilityPrompt';
+type DockerExtensionSettings =
+  | 'dockerEngineAvailabilityPrompt'
+  | 'yamlDuplicationPrompt';
 
 /**
  * Retrieves the value of a specified setting from the Docker extension's configuration.
@@ -28,6 +30,10 @@ function setExtensionSetting(
   vscode.workspace
     .getConfiguration('docker.extension')
     .update(setting, value, configurationTarget);
+}
+
+export function disableYamlDuplicationPrompt(): void {
+  setExtensionSetting('yamlDuplicationPrompt', false);
 }
 
 export function disableDockerEngineAvailabilityPrompt(): void {


### PR DESCRIPTION
## Problem Description

If Red Hat's YAML extension is installed alongside the Docker DX extension, many Compose editing features will be duplicated (such as code completion suggestions and hover tooltips).

![image](https://github.com/user-attachments/assets/0e00db78-70a9-4dee-98ab-59b286670864)

## Proposed Solution

 To help alleviate this, we will prompt the user to notify them about these duplicates and provide them with an option for removing the duplicates by disabling Red Hat's Compose support. Other non-Compose YAML files will be left unchanged.

## Proof of Work

![image](https://github.com/user-attachments/assets/dafdb72d-3910-4311-a82a-8e7f454437bd)