### PR TITLE
Create a global setting for toggling Compose editor features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Docker DX extension will be documented in this file.
 
 ### Added
 
+- created `docker.extension.experimental.composeSupport` for globally toggling Compose editor features
 - Compose
   - updated Compose schema to the latest version ([docker/docker-language-server#117](https://github.com/docker/docker-language-server/issues/117))
   - textDocument/completion
@@ -77,6 +78,10 @@ All notable changes to the Docker DX extension will be documented in this file.
     - stop flagging `BUILDKIT_SYNTAX` as an unrecognized `ARG` ([docker/docker-language-server#187](https://github.com/docker/docker-language-server/issues/187))
     - use inheritance to determine if an `ARG` is truly unused ([docker/docker-language-server#198](https://github.com/docker/docker-language-server/issues/198))
     - correct range calculations for malformed variable interpolation errors ([docker/docker-language-server#203](https://github.com/docker/docker-language-server/issues/203))
+
+### Removed
+
+- removed the `docker.extension.experimental.composeCompletions` setting in favour for the new `docker.extension.experimental.composeSupport` setting
 
 ## [0.7.0] - 2025-05-21
 

--- a/package.json
+++ b/package.json
@@ -64,10 +64,10 @@
     "configuration": {
       "title": "Docker",
       "properties": {
-        "docker.extension.experimental.composeCompletions": {
+        "docker.extension.experimental.composeSupport": {
           "type": "boolean",
-          "description": "Enable Intellisense for Compose files. You must restart Visual Studio Code after changing this value.",
-          "default": false,
+          "description": "Enable Compose editing features from the Docker DX extension. Note that changing this value requires a restart of Visual Studio Code to take effect.",
+          "default": true,
           "scope": "application",
           "tags": [
             "experimental"

--- a/src/utils/lsp/languageClient.ts
+++ b/src/utils/lsp/languageClient.ts
@@ -23,8 +23,7 @@ export class DockerLanguageClient extends LanguageClient {
     );
     params.initializationOptions = {
       dockercomposeExperimental: {
-        composeCompletion:
-          extensionConfiguration.get<boolean>('composeCompletions'),
+        composeSupport: extensionConfiguration.get<boolean>('composeSupport'),
       },
       dockerfileExperimental: {
         removeOverlappingIssues: true,


### PR DESCRIPTION
## Problem Description

Users may encounter duplicated Compose features when we bring in the latest changes from the Docker Language Server.

## Proposed Solution

Created a new `docker.extension.experimental.composeSupport` to allow users to toggle the features as they desire.

## Proof of Work

Verified the behaviour in the debugger.