### PR TITLE
Send errors to BugSnag if error telemetry is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Docker DX extension will be documented in this file.
 ### Added
 
 - created `docker.extension.experimental.composeSupport` for globally toggling Compose editor features
+- send errors to BugSnag if error telemetry is configured to be allowed and sent
 - Compose
   - updated Compose schema to the latest version ([docker/docker-language-server#117](https://github.com/docker/docker-language-server/issues/117))
   - textDocument/completion

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -30,6 +30,10 @@ If you have already opted out of sending telemetry in Visual Studio Code then no
 
 The list above does _not_ include any telemetry collected by the [Docker Language Server](https://github.com/docker/docker-language-server). For telemetry collected by the Docker Language Server, please refer to the telemetry documentation of that project.
 
+## BugSnag
+
+This extension integrates with BugSnag and sends errors and stack traces to BugSnag if telemetry is configured.
+
 ## Privacy Policy
 
 Read our [privacy policy](https://www.docker.com/legal/docker-privacy-policy/) to learn more about how the information is collected and used.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@bugsnag/js": "~8.2.0",
         "vscode-languageclient": "9.0.1"
       },
       "devDependencies": {
@@ -228,6 +229,64 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bugsnag/browser": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-8.2.0.tgz",
+      "integrity": "sha512-C4BfE3eVsjOAqoXbdrPXfKbgp/hz2H7mKBU0p11Jf9uz+5gUCfZK+39JLrQKvRXwqoDcTlBSfz9Xz5kXLyHg2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/core": "^8.2.0"
+      }
+    },
+    "node_modules/@bugsnag/core": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-8.2.0.tgz",
+      "integrity": "sha512-dFSs80ZwJ508nlC6UTLTUMdHgTaHY5UKvMiuHqstCQrQrOjqFcIv+x4o+l2WrSyOpoYhHAxDlKfzKN8AjwslQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^6.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "^0.0.2",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "node_modules/@bugsnag/cuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.2.1.tgz",
+      "integrity": "sha512-zpvN8xQ5rdRWakMd/BcVkdn2F8HKlDSbM3l7duueK590WmI1T0ObTLc1V/1e55r14WNjPd5AJTYX4yPEAFVi+Q==",
+      "license": "MIT"
+    },
+    "node_modules/@bugsnag/js": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-8.2.0.tgz",
+      "integrity": "sha512-DTtQwV1Ly5VXSOnVtzW8gSwB+ld3qIc/h0yMS836DEYUfA3V9JPwJE3+2EbD8Ea2ogkDWZ+a0jl0SNSNGiOmfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/browser": "^8.2.0",
+        "@bugsnag/node": "^8.2.0"
+      }
+    },
+    "node_modules/@bugsnag/node": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-8.2.0.tgz",
+      "integrity": "sha512-6XC/KgX61m6YFgsBQP/GaH1UzlJkJmpi3AwlZQLsXloRh3O9lM/0EIk6+2sZm+vlz+GwxCFavcuIDgVmH/qi7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/core": "^8.2.0",
+        "byline": "^5.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "^0.0.2",
+        "pump": "^3.0.0",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "node_modules/@bugsnag/safe-json-stringify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+      "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA==",
       "license": "MIT"
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2024,6 +2083,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/c8": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/c8/-/c8-9.1.0.tgz",
@@ -2934,7 +3002,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -2978,6 +3045,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-define-property": {
@@ -4354,6 +4430,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/iserror": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5310,7 +5392,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5869,9 +5950,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6539,6 +6618,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
@@ -8064,7 +8158,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "prettier:fix": "prettier --write --config .prettierrc.yml --ignore-path .prettierignore ."
   },
   "dependencies": {
+    "@bugsnag/js": "~8.2.0",
     "vscode-languageclient": "9.0.1"
   },
   "devDependencies": {

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -2,6 +2,7 @@ import https from 'https';
 import * as process from 'process';
 import * as vscode from 'vscode';
 import { extensionVersion } from '../extension';
+import Bugsnag from '@bugsnag/js';
 
 export const EVENT_CLIENT_HEARTBEAT = 'client_heartbeat';
 
@@ -13,6 +14,23 @@ interface TelemetryRecord {
 }
 
 const events: TelemetryRecord[] = [];
+
+function shouldReportToBugsnag(): boolean {
+  if (!vscode.env.isTelemetryEnabled) {
+    return false;
+  }
+
+  const config = vscode.workspace
+    .getConfiguration('docker.lsp')
+    .get('telemetry');
+  return config === 'error' || config === 'all';
+}
+
+export function notifyBugsnag(err: any): void {
+  if (shouldReportToBugsnag()) {
+    Bugsnag.notify(err);
+  }
+}
 
 export function queueTelemetryEvent(
   event: string,

--- a/src/telemetry/filter.ts
+++ b/src/telemetry/filter.ts
@@ -1,0 +1,19 @@
+function redactFilePath(path: string): string {
+  const split = path.split(/[/\\]/);
+  if (split.length < 2) {
+    return path;
+  }
+  const redacted = split.pop();
+  if (redacted === undefined) {
+    return '';
+  }
+  return `REDACTED/${redacted}`;
+}
+
+export function redact(s: string): string {
+  const words = s.split(/\s+/);
+  for (let i = 0; i < words.length; i++) {
+    words[i] = redactFilePath(words[i]);
+  }
+  return words.join(' ');
+}

--- a/src/utils/lsp/languageClient.ts
+++ b/src/utils/lsp/languageClient.ts
@@ -11,6 +11,7 @@ import { BakeBuildCommandId } from '../../extension';
 import { getTelemetryValue } from './lsp';
 import {
   EVENT_CLIENT_HEARTBEAT,
+  notifyBugsnag,
   queueTelemetryEvent,
 } from '../../telemetry/client';
 
@@ -70,6 +71,7 @@ export class DockerLanguageClient extends LanguageClient {
             action: result.action,
           });
         }
+        notifyBugsnag(error);
         return result;
       },
 


### PR DESCRIPTION
## Problem Description

Errors in the extension are being captured manually at the moment and it can be difficult to aggregate this data.

## Proposed Solution

Sending errors to BugSnag will make analysis easier as the platform provides such features out-of-the-box.

## Proof of Work

Verified that errors that have been triggered manually through local testing are getting sent to BugSnag.