### PR TITLE
Change how Compose features are exposed

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -27,6 +27,8 @@ If you have already opted out of sending telemetry in Visual Studio Code then no
   - [Microsoft's Container Tools extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-containers)
   - [Microsoft's Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
   - [Red Hat's YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+- values of certain settings from this extension
+  - `docker.extension.enableComposeLanguageServer`
 
 The list above does _not_ include any telemetry collected by the [Docker Language Server](https://github.com/docker/docker-language-server). For telemetry collected by the Docker Language Server, please refer to the telemetry documentation of that project.
 

--- a/package.json
+++ b/package.json
@@ -62,26 +62,18 @@
       ]
     },
     "configuration": {
-      "title": "Docker",
+      "title": "Docker DX",
       "properties": {
-        "docker.extension.experimental.composeSupport": {
+        "docker.extension.enableComposeLanguageServer": {
           "type": "boolean",
           "description": "Enable Compose editing features from the Docker DX extension. Note that changing this value requires a restart of Visual Studio Code to take effect.",
+          "markdownDescription": "Enable Compose editing features from the Docker DX extension. Note that changing this value requires a **restart** of Visual Studio Code to take effect.\n\nIf you have [Red Hat's YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml), note that both Docker DX and Red Hat's YAML extension are handling Compose files. This creates duplicate completions, hovers, and syntax errors.\n\nYou can follow the steps [here](https://github.com/docker/vscode-extension/blob/main/README.md#faq) to update your `settings.json` to turn off Compose support in the YAML extension and streamline your experience.",
           "default": true,
-          "scope": "application",
-          "tags": [
-            "experimental"
-          ]
+          "scope": "application"
         },
         "docker.extension.dockerEngineAvailabilityPrompt": {
           "type": "boolean",
           "description": "Be notified when Docker Engine is not available.",
-          "default": true,
-          "scope": "application"
-        },
-        "docker.extension.yamlDuplicationPrompt": {
-          "type": "boolean",
-          "description": "Determines if the user should be prompted about duplicated Compose support due to having Red Hat's YAML extension installed.",
           "default": true,
           "scope": "application"
         },

--- a/src/utils/os.ts
+++ b/src/utils/os.ts
@@ -1,7 +1,5 @@
-import * as vscode from 'vscode';
 import { access } from 'fs';
 import { spawnDockerCommand } from './spawnDockerCommand';
-import { globalStorageUri } from '../extension';
 
 export function getDockerDesktopPath(): string {
   switch (process.platform) {
@@ -29,23 +27,4 @@ export async function isDockerDesktopInstalled(): Promise<boolean> {
       },
     });
   });
-}
-
-/**
- * Creates an empty JSON schema file (with the content "{}", an empty
- * dictionary) in the global storage location of the Docker DX
- * extension. The file will be named empty.json.
- */
-export async function createEmptyComposeSchemaFile(): Promise<vscode.Uri> {
-  await vscode.workspace.fs.createDirectory(globalStorageUri);
-  const emptyComposeSchemaFile = vscode.Uri.joinPath(
-    globalStorageUri,
-    'compose',
-    'empty.json',
-  );
-  await vscode.workspace.fs.writeFile(
-    emptyComposeSchemaFile,
-    Buffer.from('{}'),
-  );
-  return emptyComposeSchemaFile;
 }

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -12,7 +12,7 @@ export async function promptUnauthenticatedDesktop(): Promise<void> {
     "Don't show again",
   );
   if (response === "Don't show again") {
-    disableDockerEngineAvailabilityPrompt();
+    await disableDockerEngineAvailabilityPrompt();
   }
 }
 
@@ -26,7 +26,7 @@ export async function promptOpenDockerDesktop(): Promise<void> {
     'Open Docker Desktop',
   );
   if (response === "Don't show again") {
-    disableDockerEngineAvailabilityPrompt();
+    await disableDockerEngineAvailabilityPrompt();
   } else if (response === 'Open Docker Desktop') {
     const dockerDesktopPath = getDockerDesktopPath();
     if (process.platform === 'darwin') {
@@ -64,7 +64,7 @@ export async function promptInstallDesktop(
     'Install Docker Desktop',
   );
   if (response === "Don't show again") {
-    disableDockerEngineAvailabilityPrompt();
+    await disableDockerEngineAvailabilityPrompt();
   } else if (response === 'Install Docker Desktop') {
     vscode.env.openExternal(
       vscode.Uri.parse('https://docs.docker.com/install/'),

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 type DockerExtensionSettings =
   | 'dockerEngineAvailabilityPrompt'
-  | 'yamlDuplicationPrompt';
+  | 'enableComposeLanguageServer';
 
 /**
  * Retrieves the value of a specified setting from the Docker extension's configuration.
@@ -15,27 +15,31 @@ export function getExtensionSetting(setting: DockerExtensionSettings) {
   return vscode.workspace.getConfiguration('docker.extension').get(setting);
 }
 
+export function inspectExtensionSetting(setting: DockerExtensionSettings) {
+  return vscode.workspace.getConfiguration('docker.extension').inspect(setting);
+}
+
 /**
  * Updates the value of a specified setting in the Docker extension's configuration.
  *
  * @param setting - The name of the setting to update.
  * @param value - The new value to set for the specified setting.
  */
-function setExtensionSetting(
+async function setExtensionSetting(
   setting: string,
   value: string | boolean,
   configurationTarget: vscode.ConfigurationTarget = vscode.ConfigurationTarget
     .Global,
-): void {
-  vscode.workspace
+): Promise<void> {
+  return vscode.workspace
     .getConfiguration('docker.extension')
     .update(setting, value, configurationTarget);
 }
 
-export function disableYamlDuplicationPrompt(): void {
-  setExtensionSetting('yamlDuplicationPrompt', false);
+export async function disableDockerEngineAvailabilityPrompt(): Promise<void> {
+  return setExtensionSetting('dockerEngineAvailabilityPrompt', false);
 }
 
-export function disableDockerEngineAvailabilityPrompt(): void {
-  setExtensionSetting('dockerEngineAvailabilityPrompt', false);
+export async function disableEnableComposeLanguageServer(): Promise<void> {
+  return setExtensionSetting('enableComposeLanguageServer', false);
 }


### PR DESCRIPTION
Previously, we would present a toast to the user to notify them that they would be seeing duplicates if Red Hat's YAML extension was installed. We will now auto-disable the Compose features if the YAML extension is installed.

If the user does some digging into the settings, they can read the description and learn more about the situation from the FAQ in our README.md. They can then proceed to opt-in to our Compose features manually with the full understanding of the implications of turning it on. If they follow the steps, they will also be able to disable the duplicates from Red Hat's extension.

The intent here is to give users full control over their Compose editing experience in Visual Studio Code. If they want to use Red Hat's YAML language server, they can. And if they want to use ours, they can. Whichever one they choose, there will be documentation available to opt out of the other so that duplicates will not appear.