### PR TITLE
Create toggles for each specific vulnerability warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to the Docker DX extension will be documented in this file.
 
 - created `docker.extension.experimental.composeSupport` for globally toggling Compose editor features
 - send errors to BugSnag if error telemetry is configured to be allowed and sent
+- Dockerfile
+  - textDocument/hover
+    - support configuring specific vulnerability hovers with an experimental setting ([#101](https://github.com/docker/vscode-extension/issues/101))
+  - textDocument/publishDiagnostics
+    - support filtering specific vulnerability diagnostics with an experimental setting ([#101](https://github.com/docker/vscode-extension/issues/101))
 - Compose
   - updated Compose schema to the latest version ([docker/docker-language-server#117](https://github.com/docker/docker-language-server/issues/117))
   - textDocument/completion
@@ -40,6 +45,9 @@ All notable changes to the Docker DX extension will be documented in this file.
     - support rename preparation requests ([docker/docker-language-server#150](https://github.com/docker/docker-language-server/issues/150))
   - textDocument/rename
     - support renaming named references of services, networks, volumes, configs, and secrets ([docker/docker-language-server#149](https://github.com/docker/docker-language-server/issues/149))
+- Bake
+  - textDocument/publishDiagnostics
+    - support filtering specific vulnerability diagnostics with an experimental setting ([#101](https://github.com/docker/vscode-extension/issues/101))
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -107,6 +107,38 @@
           "tags": [
             "experimental"
           ]
+        },
+        "docker.lsp.experimental.scout.criticalHighVulnerabilities": {
+          "markdownDescription": "Determines if `critical_high_vulnerabilities` diagnostics should be shown. If `docker.lsp.experimental.vulnerabilityScanning` is false then this setting will be ignored.",
+          "default": true,
+          "type": "boolean",
+          "tags": [
+            "experimental"
+          ]
+        },
+        "docker.lsp.experimental.scout.notPinnedDigest": {
+          "markdownDescription": "Determines if `not_pinned_digest` diagnostics should be shown. If `docker.lsp.experimental.vulnerabilityScanning` is false then this setting will be ignored.",
+          "default": false,
+          "type": "boolean",
+          "tags": [
+            "experimental"
+          ]
+        },
+        "docker.lsp.experimental.scout.recommendedTag": {
+          "markdownDescription": "Determines if `recommended_tag` diagnostics should be shown. If `docker.lsp.experimental.vulnerabilityScanning` is false then this setting will be ignored.",
+          "default": false,
+          "type": "boolean",
+          "tags": [
+            "experimental"
+          ]
+        },
+        "docker.lsp.experimental.scout.vulnerabilities": {
+          "markdownDescription": "Determines if `vulnerabilities` diagnostics should be shown. If `docker.lsp.experimental.vulnerabilityScanning` is false then this setting will be ignored.",
+          "default": true,
+          "type": "boolean",
+          "tags": [
+            "experimental"
+          ]
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -268,6 +268,10 @@ function listenForConfigurationChanges(ctx: vscode.ExtensionContext) {
         const configurations = [
           'docker.lsp.telemetry',
           'docker.lsp.experimental.vulnerabilityScanning',
+          'docker.lsp.experimental.scout.criticalHighVulnerabilities',
+          'docker.lsp.experimental.scout.notPinnedDigest',
+          'docker.lsp.experimental.scout.recommendedTag',
+          'docker.lsp.experimental.scout.vulnerabilities',
         ];
         const filtered = configurations.filter((config) =>
           e.affectsConfiguration(config),

--- a/src/utils/lsp/lsp.ts
+++ b/src/utils/lsp/lsp.ts
@@ -156,12 +156,8 @@ async function createNative(ctx: vscode.ExtensionContext): Promise<boolean> {
         configuration: (params, token, next) => {
           const result = next(params, token) as any[];
           return result.map((value) => {
-            return {
-              experimental: {
-                vulnerabilityScanning: value.experimental.vulnerabilityScanning,
-              },
-              telemetry: getTelemetryValue(value.telemetry),
-            };
+            value.telemetry = getTelemetryValue(value.telemetry);
+            return value;
           });
         },
       },


### PR DESCRIPTION
## Problem Description

The `recommended_tag` warnings are misleading if LTS images are used. Users would like a way to disable these warnings.

## Proposed Solution

Vulnerability warnings can now be toggled individually so that you can choose to get vulnerability warnings but not warnings about recommended tags.

Fixes #101.

## Proof of Work

![image](https://github.com/user-attachments/assets/6fc1bfd1-4f5e-49f6-aa8e-29c6e63a61ee)