### PR TITLE
Provide code actions to easily opt-out of Scout warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ All notable changes to the Docker DX extension will be documented in this file.
 ### Added
 
 - send errors to BugSnag if error telemetry is configured to be allowed and sent
-- created `docker.extension.enableComposeLanguageServer` for globally toggling Compose editor features
 - Dockerfile
+  - provide code actions for Scout vulnerabilities that will open the settings page so that users can opt-out of them easily ([#130](https://github.com/docker/vscode-extension/issues/130))
   - textDocument/hover
     - support configuring specific vulnerability hovers with an experimental setting ([#101](https://github.com/docker/vscode-extension/issues/101))
   - textDocument/publishDiagnostics
     - support filtering specific vulnerability diagnostics with an experimental setting ([#101](https://github.com/docker/vscode-extension/issues/101))
 - Compose
+  - created `docker.extension.enableComposeLanguageServer` for globally toggling Compose editor features
   - updated Compose schema to the latest version ([docker/docker-language-server#117](https://github.com/docker/docker-language-server/issues/117))
   - textDocument/completion
     - add support for attribute name and value completion
@@ -91,7 +92,8 @@ All notable changes to the Docker DX extension will be documented in this file.
 
 ### Removed
 
-- removed the `docker.extension.experimental.composeCompletions` setting in favour for the new `docker.extension.enableComposeLanguageServer` setting
+- Compose
+  - removed the `docker.extension.experimental.composeCompletions` setting in favour for the new `docker.extension.enableComposeLanguageServer` setting
 
 ## [0.7.0] - 2025-05-21
 


### PR DESCRIPTION
## Problem Description

Our users would like an easy way to opt-out of Scout warnings.

## Proposed Solution

By providing an opt-out code action, users can easily toggle them off without having to rely on the documentation or trying to guess and figure out the name from the Settings editor.

Fixes #130.

## Proof of Work

![image](https://github.com/user-attachments/assets/4c7e4a8b-8eda-444e-95d2-def2e8381d7e)