### PR TITLE
Disable Compose editing features correctly

### DIFF
--- a/src/utils/lsp/languageClient.ts
+++ b/src/utils/lsp/languageClient.ts
@@ -19,12 +19,13 @@ export class DockerLanguageClient extends LanguageClient {
   protected fillInitializeParams(params: InitializeParams): void {
     super.fillInitializeParams(params);
     const dockerConfiguration = vscode.workspace.getConfiguration('docker.lsp');
-    const extensionConfiguration = vscode.workspace.getConfiguration(
-      'docker.extension.experimental',
-    );
+    const extensionConfiguration =
+      vscode.workspace.getConfiguration('docker.extension');
     params.initializationOptions = {
       dockercomposeExperimental: {
-        composeSupport: extensionConfiguration.get<boolean>('composeSupport'),
+        composeSupport: extensionConfiguration.get<boolean>(
+          'enableComposeLanguageServer',
+        ),
       },
       dockerfileExperimental: {
         removeOverlappingIssues: true,


### PR DESCRIPTION
We changed the name of the settings in #125 but forgot to make the corresponding change in `languageClient.ts`.