### PR TITLE
Note that the enableComposeLanguageServer must be explicitly set to true

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -25,12 +25,17 @@ If yes, you can refer to the steps below to remove the duplicates. Alternatively
 - [Red Hat's YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) (powered by [redhat-developer/yaml-language-server](https://github.com/redhat-developer/yaml-language-server))
   1. To disable duplicates from this extension, create a JSON file with `{}` as its content and save it somewhere. Let's say it is at `/home/user/empty.json`.
   2. Open the [Command Palette](https://code.visualstudio.com/api/ux-guidelines/command-palette) in Visual Studio Code and open "Preferences: Open User Settings (JSON)".
-  3. Create an object attribute for `yaml.schemas` if it does not already exist.
-  4. Inside the `yaml.schemas` object, map your empty JSON file to Compose YAML files by following the snippet below.
-  5. YAML files named `compose*y*ml` or `docker-compose*y*ml` will now no longer have the Compose schema associated with them in Red Hat's extension so Red Hat's extension will stop providing YAML features for Compose files. This admittedly is a strange way to disable YAML features for a given file but it is the only known workaround for resolving this until [redhat-developer/vscode-yaml#1088](https://github.com/redhat-developer/vscode-yaml/issues/1088) is implemented.
+  3. Set `docker.extension.enableComposeLanguageServer` to `true` by following the snippet below.
+  4. Create an object attribute for `yaml.schemas` if it does not already exist.
+  5. Inside the `yaml.schemas` object, map your empty JSON file to Compose YAML files by following the snippet below.
+  6. YAML files named `compose*y*ml` or `docker-compose*y*ml` will now no longer have the Compose schema associated with them in Red Hat's extension so Red Hat's extension will stop providing YAML features for Compose files. This admittedly is a strange way to disable YAML features for a given file but it is the only known workaround for resolving this until [redhat-developer/vscode-yaml#1088](https://github.com/redhat-developer/vscode-yaml/issues/1088) is implemented.
 
 ```JSONC
 {
+  // this must be explicitly set to true in your settings.json file or
+  // the auto-deduplication logic will programmatically set the value to
+  // false if it detects that Red Hat's YAML extension is installed
+  "docker.extension.enableComposeLanguageServer": true,
   "yaml.schemas": {
     // this tells Red Hat's YAML extension to consider Compose YAML
     // files as not having a schema so it will stop suggesting code


### PR DESCRIPTION
If we do not tell the user to set `docker.extension.enableComposeLanguageServer` to `true` then the deduplication will not work properly because the setting will be set to `false` even if the change has been done in the `yaml.schemas` object. The new additional step that has been added should help explain the situation to the user.