### PR TITLE
Include the Dockerfile Language Server in the extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- include the Dockerfile Language Server written in TypeScript into the extension
+
 ## [0.10.0] - 2025-06-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@bugsnag/js": "~8.2.0",
+        "dockerfile-language-server-nodejs": "0.14.0",
         "vscode-languageclient": "9.0.1"
       },
       "devDependencies": {
@@ -28,6 +29,7 @@
         "prettier": "^3.5.3",
         "ts-loader": "^9.5.1",
         "typescript": "^5.4.5",
+        "umd-compat-loader": "^2.1.2",
         "vscode-extension-tester": "^8.13.0",
         "webpack": "^5.92.1",
         "webpack-cli": "^5.1.4"
@@ -1832,6 +1834,16 @@
         "node": "*"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.9.14",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.14.tgz",
+      "integrity": "sha512-Ebvx7/0lLboCdyEmAw/4GqwBeKIijPveXNiVGhCGCNxc7z26T5he7DC6ARxu8ByKuzUZZcLog+VP8GMyZrBzJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1876,6 +1888,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2856,6 +2878,81 @@
         "node": ">=8"
       }
     },
+    "node_modules/dockerfile-ast": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.0.tgz",
+      "integrity": "sha512-HYpjuL0IEC2lYflTpWD0RLNSZYhQxLwYRYsoEjnCP7nu/OlFx1BVrU6X/Y8ETVsa2hojhG2OTJVxleH5Wrlq+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dockerfile-language-server-nodejs": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.14.0.tgz",
+      "integrity": "sha512-zbHDuaVHJrgnInOp+bGnMENikCDNGdEad8ro7WndQLGdRKjMC6Gndw2UKTv4WVlJTeAzwp8cOiu1VHkB4nmGgg==",
+      "license": "MIT",
+      "dependencies": {
+        "dockerfile-language-service": "0.15.0",
+        "dockerfile-utils": "0.16.2",
+        "vscode-languageserver": "~8.0.0",
+        "vscode-languageserver-textdocument": "~1.0.8"
+      },
+      "bin": {
+        "docker-langserver": "bin/docker-langserver"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dockerfile-language-service": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.15.0.tgz",
+      "integrity": "sha512-DvfabBrOQWhPzFtO6GvuEyv4ojdh3sr7+0uPc+TM+azJRrd7+zWvf6F8/AFVfmd2Kvdl9nvikmKIwSLEp0Wowg==",
+      "license": "MIT",
+      "dependencies": {
+        "dockerfile-ast": "0.7.0",
+        "dockerfile-utils": "0.16.2",
+        "vscode-languageserver-textdocument": "1.0.8",
+        "vscode-languageserver-types": "3.17.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dockerfile-language-service/node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==",
+      "license": "MIT"
+    },
+    "node_modules/dockerfile-language-service/node_modules/vscode-languageserver-types": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
+      "license": "MIT"
+    },
+    "node_modules/dockerfile-utils": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.16.2.tgz",
+      "integrity": "sha512-0BHCYRYm5uk/xdL6jv1vLDxJ+FY812sQumRMkLB33f4FRB9VZsDk6ckUeSWlYOWHP9/VhmM0colmpXT/j2OTzA==",
+      "license": "MIT",
+      "dependencies": {
+        "dockerfile-ast": "0.7.0",
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
+      },
+      "bin": {
+        "dockerfile-utils": "bin/dockerfile-utils"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2983,6 +3080,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.0",
@@ -3274,6 +3381,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha512-AWwVMNxwhN8+NIPQzAQZCm7RkLC4RbM3B1OobMuyp3i+w73X57KCKaVIxaRZb+DYCojq7rspo+fmuQfAboyhFg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -4593,6 +4714,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
@@ -4770,6 +4904,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      }
+    },
+    "node_modules/loader-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -5933,6 +6082,16 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6104,6 +6263,42 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.11.23",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+      "integrity": "sha512-+nixG+3NugceyR8O1bLU45qs84JgI3+8EauyRZafLgC9XbdAOIVgwV1Pe2da0YzGo62KzWoZwUpVEQf6qNAXWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "0.9.6",
+        "esprima": "~3.1.0",
+        "private": "~0.1.5",
+        "source-map": "~0.5.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/recast/node_modules/ast-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "integrity": "sha512-qEdtR2UH78yyHX/AUNfXmJTlM48XoFZKBdwi1nzkI1mJL21cmbu0cvjxjpkXJ5NENMq42H+hNs8VLJcqXLerBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rechoir": {
@@ -7283,6 +7478,18 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/umd-compat-loader": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/umd-compat-loader/-/umd-compat-loader-2.1.2.tgz",
+      "integrity": "sha512-RkTlsfrCxUISWqiTtYFFJank7b2Hhl4V2pc29nl0xOEGvvuVkpy1xnufhXfTituxgpW0HSrDk0JHlvPYZxEXKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ast-types": "^0.9.2",
+        "loader-utils": "^1.0.3",
+        "recast": "^0.11.17"
+      }
+    },
     "node_modules/underscore": {
       "version": "1.13.7",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
@@ -7808,6 +8015,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/vscode-languageserver": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz",
+      "integrity": "sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.2"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
@@ -7818,10 +8037,41 @@
         "vscode-languageserver-types": "3.17.5"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.0.2",
+        "vscode-languageserver-types": "3.17.2"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-types": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
       "license": "MIT"
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
   },
   "dependencies": {
     "@bugsnag/js": "~8.2.0",
+    "dockerfile-language-server-nodejs": "0.14.0",
     "vscode-languageclient": "9.0.1"
   },
   "devDependencies": {
@@ -179,6 +180,7 @@
     "prettier": "^3.5.3",
     "ts-loader": "^9.5.1",
     "typescript": "^5.4.5",
+    "umd-compat-loader": "^2.1.2",
     "vscode-extension-tester": "^8.13.0",
     "webpack": "^5.92.1",
     "webpack-cli": "^5.1.4"

--- a/src/utils/lsp/languageClient.ts
+++ b/src/utils/lsp/languageClient.ts
@@ -18,6 +18,11 @@ import {
 export class DockerLanguageClient extends LanguageClient {
   protected fillInitializeParams(params: InitializeParams): void {
     super.fillInitializeParams(params);
+    const removeOverlappingIssues =
+      vscode.extensions.getExtension('ms-azuretools.vscode-docker') !==
+        undefined ||
+      vscode.extensions.getExtension('ms-azuretools.vscode-containers') !==
+        undefined;
     const dockerConfiguration = vscode.workspace.getConfiguration('docker.lsp');
     const extensionConfiguration =
       vscode.workspace.getConfiguration('docker.extension');
@@ -27,9 +32,7 @@ export class DockerLanguageClient extends LanguageClient {
           'enableComposeLanguageServer',
         ),
       },
-      dockerfileExperimental: {
-        removeOverlappingIssues: true,
-      },
+      dockerfileExperimental: { removeOverlappingIssues },
       telemetry: getTelemetryValue(dockerConfiguration.get('telemetry')),
     };
     params.capabilities.experimental = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,11 +12,15 @@ const extensionConfig = {
   target: 'node', // VS Code extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
   mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
 
-  entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
+  entry: {
+    './extension': './src/extension.ts',
+    './dockerfile-language-server-nodejs/lib/server':
+      './node_modules/dockerfile-language-server-nodejs/lib/server.js',
+  }, // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {
     // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
     path: path.resolve(__dirname, 'dist'),
-    filename: 'extension.js',
+    filename: '[name].js',
     libraryTarget: 'commonjs2',
   },
   stats: {
@@ -46,6 +50,11 @@ const extensionConfig = {
             loader: 'ts-loader',
           },
         ],
+      },
+      {
+        // Unpack UMD module headers used in some modules since webpack doesn't handle them.
+        test: /dockerfile-language-service|vscode-languageserver-types/,
+        use: { loader: 'umd-compat-loader' },
       },
     ],
   },


### PR DESCRIPTION
## Problem Description

Users may install the Docker DX extension expecting to get editing features for Dockerfiles. However, we do not currently provide any editing features for Dockerfiles as the Docker Language Server only adds linting support for Dockerfiles.

## Proposed Solution

The [Dockerfile Language Server](https://github.com/rcjsuen/dockerfile-language-server) provides features that the [Docker Language Server](https://github.com/docker/docker-language-server) does not provide so bundling it in the extension will improve the overall editing experience of Dockerfiles.

If Microsoft's Docker extension or the Container Tools extension is installed, the Dockerfile Language Server will not be started. This is because Microsoft's extensions already include the Dockerfile Language Server. If we also started the Dockerfile Language Server on our side then users may get duplicated information which we want to avoid.

## Proof of Work

I confirm that I've tested the extension in a few different cases in the debugger.