### PR TITLE
Draw divider lines between build targets in a Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to the Docker DX extension will be documented in this file.
 
 ### Added
 
-- include the Dockerfile Language Server written in TypeScript into the extension
+- Dockerfile
+  - include the Dockerfile Language Server written in TypeScript into the extension
+  - draw horizontal lines between each `FROM` instruction to help users visually distinguish the different parts of a Dockerfile ([#147](https://github.com/docker/vscode-extension/issues/147))
 
 ## [0.10.0] - 2025-06-12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@bugsnag/js": "~8.2.0",
+        "dockerfile-ast": "0.7.0",
         "dockerfile-language-server-nodejs": "0.14.0",
         "vscode-languageclient": "9.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
   },
   "dependencies": {
     "@bugsnag/js": "~8.2.0",
+    "dockerfile-ast": "0.7.0",
     "dockerfile-language-server-nodejs": "0.14.0",
     "vscode-languageclient": "9.0.1"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import {
   inspectExtensionSetting,
 } from './utils/settings';
 import { redact } from './telemetry/filter';
+import { hookDecorators } from './utils/editor';
 
 export const BakeBuildCommandId = 'dockerLspClient.bake.build';
 export const ScoutImageScanCommandId = 'docker.scout.imageScan';
@@ -152,6 +153,7 @@ async function toggleComposeLanguageServerSetting(): Promise<string> {
 }
 
 export async function activate(ctx: vscode.ExtensionContext) {
+  hookDecorators(ctx);
   const composeSetting = await toggleComposeLanguageServerSetting();
   extensionVersion = String(ctx.extension.packageJSON.version);
   Bugsnag.start({

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import { DockerfileParser } from 'dockerfile-ast';
+
+/**
+ * Decoration that inserts a horizontal line into the editor.
+ */
+const decoration = vscode.window.createTextEditorDecorationType({
+  isWholeLine: true,
+  borderWidth: '1px 0 0 0',
+  borderStyle: 'solid',
+  borderColor: new vscode.ThemeColor('panelTitle.activeBorder'),
+});
+
+function getDecorationRanges(document: vscode.TextDocument): vscode.Range[] {
+  if (document.languageId === 'dockerfile' && document.uri.scheme === 'file') {
+    const dockerfile = DockerfileParser.parse(document.getText());
+    return dockerfile.getFROMs().map((from) => {
+      const line = from.getRange().start.line;
+      return new vscode.Range(line, 0, line, 0);
+    });
+  }
+  return [];
+}
+
+export function hookDecorators(ctx: vscode.ExtensionContext): void {
+  vscode.window.visibleTextEditors.forEach((editor) =>
+    editor.setDecorations(decoration, getDecorationRanges(editor.document)),
+  );
+
+  vscode.window.onDidChangeVisibleTextEditors(
+    (editors) => {
+      for (const editor of editors) {
+        editor.setDecorations(decoration, getDecorationRanges(editor.document));
+      }
+    },
+    null,
+    ctx.subscriptions,
+  );
+
+  vscode.workspace.onDidChangeTextDocument(
+    (event) => {
+      for (const editor of vscode.window.visibleTextEditors) {
+        if (
+          event.document.uri.scheme === editor.document.uri.scheme &&
+          event.document.uri.path === editor.document.uri.path
+        ) {
+          editor.setDecorations(
+            decoration,
+            getDecorationRanges(editor.document),
+          );
+        }
+      }
+    },
+    null,
+    ctx.subscriptions,
+  );
+}


### PR DESCRIPTION
## Problem Description

If a Dockerfile has many stages of varying sizes, it can be difficult to tell from scanning the file where each stage is.

## Proposed Solution

We will draw divider lines between every `FROM` instruction. This will help clearly visualize where a build stage starts and ends.

Fixes #147.

## Proof of Work

![image](https://github.com/user-attachments/assets/fb41a817-2717-4e9b-89ff-9fa361dc4b9d)