### PR TITLE
Add a setting to toggle the build stage divider lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Docker DX extension will be documented in this file.
 - Dockerfile
   - include the Dockerfile Language Server written in TypeScript into the extension
   - draw horizontal lines between each `FROM` instruction to help users visually distinguish the different parts of a Dockerfile ([#147](https://github.com/docker/vscode-extension/issues/147))
+    - a new `docker.extension.editor.dockerfileBuildStageDecorationLines` setting to toggle the divider lines, defaults to `true`
 
 ## [0.10.0] - 2025-06-12
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,12 @@
           "default": true,
           "scope": "application"
         },
+        "docker.extension.editor.dockerfileBuildStageDecorationLines": {
+          "type": "boolean",
+          "description": "Render a divider line between each build stage of a Dockerfile.",
+          "default": true,
+          "scope": "resource"
+        },
         "docker.lsp.telemetry": {
           "type": "string",
           "description": "Determines what telemetry is collected by Docker. If vscode.env.isTelemetryEnabled is false, then telemetry collection is disabled regardless of what has been set for this configuration value.",


### PR DESCRIPTION
## Problem Description

Not everyone may want to see the new divider lines for the build stages.

## Proposed Solution

We will draw the lines by default but if someone wants them removed they can toggle the new `docker.extension.editor.dockerfileBuildStageDecorationLines` setting.

## Proof of Work

![image](https://github.com/user-attachments/assets/b1e5ad6b-c1e5-4879-8093-829d643c4b26)