### PR TITLE
Add initial buildx DAP integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,9 +61,42 @@
         }
       ]
     },
+    "debuggers": [
+      {
+        "type": "dockerfile",
+        "languages": [
+          "dockerfile"
+        ],
+        "label": "Dockerfile Debug",
+        "configurationAttributes": {
+          "launch": {
+            "required": [
+              "dockerfile"
+            ],
+            "properties": {
+              "dockerfile": {
+                "type": "string",
+                "description": "Path to a Dockerfile",
+                "default": "${workspaceFolder}/Dockerfile"
+              }
+            }
+          }
+        }
+      }
+    ],
     "configuration": {
       "title": "Docker DX",
       "properties": {
+        "docker.extension.enableBuildDebugging": {
+          "type": "boolean",
+          "description": "Enables build debugging. Note that changing this value requires a restart of Visual Studio Code to take effect.",
+          "markdownDescription": "Enable Compose editing features from the Docker DX extension. Note that changing this value requires a **restart** of Visual Studio Code to take effect.",
+          "default": false,
+          "scope": "application",
+          "tags": [
+            "experimental"
+          ]
+        },
         "docker.extension.enableComposeLanguageServer": {
           "type": "boolean",
           "description": "Enable Compose editing features from the Docker DX extension. Note that changing this value requires a restart of Visual Studio Code to take effect.",

--- a/src/dap/config.ts
+++ b/src/dap/config.ts
@@ -1,0 +1,137 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { getExtensionSetting } from '../utils/settings';
+
+class DebugAdapterExecutableFactory
+  implements vscode.DebugAdapterDescriptorFactory
+{
+  createDebugAdapterDescriptor(
+    session: vscode.DebugSession,
+  ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+    const parent = path.dirname(session.configuration.dockerfile);
+    return new vscode.DebugAdapterExecutable(
+      'docker',
+      [
+        'buildx',
+        'dap',
+        'build',
+        '-f',
+        session.configuration.dockerfile,
+        parent,
+      ],
+      {
+        cwd: parent,
+        env: { BUILDX_EXPERIMENTAL: '1' },
+      },
+    );
+  }
+}
+
+class DockerfileConfigurationProvider
+  implements vscode.DebugConfigurationProvider
+{
+  resolveDebugConfiguration(
+    _folder: vscode.WorkspaceFolder | undefined,
+    config: vscode.DebugConfiguration,
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
+    // this can happen when debugging without anything in launch.json
+    if (!config.type && !config.request && !config.name) {
+      const editor = vscode.window.activeTextEditor;
+      if (editor !== undefined && editor.document.languageId === 'dockerfile') {
+        config.type = 'dockerfile';
+        config.name = 'Debug Dockerfile';
+        config.request = 'launch';
+        config.dockerfile = editor.document.uri.fsPath;
+      }
+    }
+    return config;
+  }
+}
+
+class DockerfileDebugAdapterTracker implements vscode.DebugAdapterTracker {
+  constructor(
+    private id: string,
+    private name: string,
+    private channel: vscode.OutputChannel,
+  ) {}
+
+  log(logLevel: string, message: any): void {
+    message.id = this.id;
+    message.name = this.name;
+    this.channel.appendLine(
+      `${new Date().toISOString()} [${logLevel}] ${JSON.stringify(message)}`,
+    );
+  }
+
+  onWillStartSession(): void {
+    this.log('debug', { message: 'DAP session about to be started' });
+  }
+
+  onWillStopSession(): void {
+    this.log('debug', { message: 'DAP session about to be stopped' });
+  }
+
+  onWillReceiveMessage(message: any): void {
+    this.log('debug', {
+      message: 'DAP message will be received from the editor',
+      dapMessage: message,
+    });
+  }
+
+  onDidSendMessage(message: any): void {
+    this.log('debug', {
+      message: 'DAP message has been sent to the editor',
+      dapMessage: message,
+    });
+  }
+
+  onExit(code: number | undefined, signal: string | undefined): void {
+    const message = { message: 'DAP exited', code: code, signal: signal };
+    if (code === 0) {
+      this.log('debug', message);
+    } else {
+      this.log('error', message);
+    }
+  }
+
+  onError(error: Error): void {
+    this.log('error', {
+      message: 'DAP error occurred',
+      dapMessage: { error: String(error) },
+    });
+  }
+}
+
+export function setupDebugging(ctx: vscode.ExtensionContext) {
+  if (!getExtensionSetting<boolean>('enableBuildDebugging')) {
+    return;
+  }
+
+  let channel = vscode.window.createOutputChannel('Dockerfile Debug', 'log');
+
+  ctx.subscriptions.push(
+    vscode.debug.registerDebugConfigurationProvider(
+      'dockerfile',
+      new DockerfileConfigurationProvider(),
+    ),
+  );
+
+  ctx.subscriptions.push(
+    vscode.debug.registerDebugAdapterDescriptorFactory(
+      'dockerfile',
+      new DebugAdapterExecutableFactory(),
+    ),
+  );
+
+  vscode.debug.registerDebugAdapterTrackerFactory('dockerfile', {
+    createDebugAdapterTracker(
+      session,
+    ): vscode.ProviderResult<vscode.DebugAdapterTracker> {
+      return new DockerfileDebugAdapterTracker(
+        session.id,
+        session.name,
+        channel,
+      );
+    },
+  });
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import {
 } from './utils/settings';
 import { redact } from './telemetry/filter';
 import { hookDecorators } from './utils/editor';
+import { setupDebugging } from './dap/config';
 
 export const BakeBuildCommandId = 'dockerLspClient.bake.build';
 export const ScoutImageScanCommandId = 'docker.scout.imageScan';
@@ -153,6 +154,7 @@ async function toggleComposeLanguageServerSetting(): Promise<string> {
 }
 
 export async function activate(ctx: vscode.ExtensionContext) {
+  setupDebugging(ctx);
   hookDecorators(ctx);
   const composeSetting = await toggleComposeLanguageServerSetting();
   extensionVersion = String(ctx.extension.packageJSON.version);

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -2,7 +2,8 @@ import * as vscode from 'vscode';
 
 type DockerExtensionSettings =
   | 'dockerEngineAvailabilityPrompt'
-  | 'enableComposeLanguageServer';
+  | 'enableComposeLanguageServer'
+  | 'enableBuildDebugging';
 
 /**
  * Retrieves the value of a specified setting from the Docker extension's configuration.
@@ -10,9 +11,8 @@ type DockerExtensionSettings =
  * @param setting - The name of the setting to retrieve.
  * @returns The value of the specified setting, or `undefined` if the setting is not found.
  */
-
-export function getExtensionSetting(setting: DockerExtensionSettings) {
-  return vscode.workspace.getConfiguration('docker.extension').get(setting);
+export function getExtensionSetting<T>(setting: DockerExtensionSettings) {
+  return vscode.workspace.getConfiguration('docker.extension').get<T>(setting);
 }
 
 export function inspectExtensionSetting(setting: DockerExtensionSettings) {


### PR DESCRIPTION
Integrate buildx's DAP support into the extension. To test this, users must explicitly opt-in with the experimental `docker.extension.enableBuildDebugging` setting and restart VS Code.