### PR TITLE
debugger: update debugger components

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"${workspaceFolder}/test/workspace"
 			],
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "publisher": "docker",
   "categories": [
     "Programming Languages",
-    "Linters"
+    "Linters",
+    "Debuggers"
   ],
   "repository": {
     "type": "git",
@@ -34,6 +35,10 @@
         "title": "Scan for CVEs with Docker Scout",
         "command": "docker.scout.imageScan",
         "enablement": "(view == dockerImages || view == vscode-containers.views.images) && viewItem == image"
+      },
+      {
+        "title": "Build with Debugger",
+        "command": "docker.debug.editorContents"
       }
     ],
     "languages": [
@@ -67,21 +72,54 @@
         "languages": [
           "dockerfile"
         ],
-        "label": "Dockerfile Debug",
+        "label": "Docker: Build",
         "configurationAttributes": {
           "launch": {
-            "required": [
-              "dockerfile"
-            ],
+            "required": [],
             "properties": {
               "dockerfile": {
                 "type": "string",
-                "description": "Path to a Dockerfile",
-                "default": "${workspaceFolder}/Dockerfile"
+                "description": "Relative path from the context to the dockerfile.",
+                "default": "Dockerfile"
+              },
+              "contextPath": {
+                "type": "string",
+                "description": "Path to the context.",
+                "default": "${workspaceFolder}"
+              },
+              "target": {
+                "type": "string",
+                "description": "Target build stage to build."
+              },
+              "args": {
+                "type": "array",
+                "description": "Arguments to pass to the build."
               }
             }
           }
-        }
+        },
+        "initialConfigurations": [
+          {
+            "type": "dockerfile",
+            "request": "launch",
+            "name": "Docker: Build",
+            "dockerfile": "Dockerfile",
+            "contextPath": "${workspaceFolder}"
+          }
+        ],
+        "configurationSnippets": [
+          {
+            "label": "Docker: Build",
+            "description": "A new configuration for debugging a user selected Dockerfile.",
+            "body": {
+              "type": "dockerfile",
+              "request": "launch",
+              "name": "Docker: Build",
+              "dockerfile": "${2:Dockerfile}",
+              "contextPath": "^\"\\${workspaceFolder}\""
+            }
+          }
+        ]
       }
     ],
     "configuration": {
@@ -90,9 +128,8 @@
         "docker.extension.enableBuildDebugging": {
           "type": "boolean",
           "description": "Enables build debugging. Note that changing this value requires a restart of Visual Studio Code to take effect.",
-          "markdownDescription": "Enable Compose editing features from the Docker DX extension. Note that changing this value requires a **restart** of Visual Studio Code to take effect.",
+          "markdownDescription": "Enable build debugging features from the Docker DX extension. Note that changing this value requires a **restart** of Visual Studio Code to take effect.",
           "default": false,
-          "scope": "application",
           "tags": [
             "experimental"
           ]

--- a/test/workspace/Dockerfile
+++ b/test/workspace/Dockerfile
@@ -1,0 +1,15 @@
+ARG FOO="init"
+ARG AAA="init"
+
+FROM busybox AS build1
+RUN echo hello > /hello
+
+FROM busybox AS build2
+ARG FOO
+ARG AAA
+RUN echo hi > /hi && cat /fail
+
+FROM scratch
+COPY --from=build1 /hello /
+RUN cat fail > /
+COPY --from=build2 /hi /


### PR DESCRIPTION
Debugger options have been updated to reflect the current version on
master more closely.

The names have been renamed to `Docker: Build` instead of `Dockerfile
Debug`. The reason for this is to make the naming more consistent and
make it so the bake target could be called `Docker: Bake`.

Initial configurations and configuration snippets now more closely align
with the default attributes most projects should expect.

The vscode extension host debugging now uses `test/workspace` as the
workspace folder and included a default dockerfile that can be used for
testing debugging.
