### PR TITLE
Improve the experimental build debugging feature experience for new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
-## [0.11.0] - 2025-06-23
+## [Unreleased]
 
 ### Added
 
-- Dockerfile
-  - include the Dockerfile Language Server written in TypeScript into the extension
-  - draw horizontal lines between each `FROM` instruction to help users visually distinguish the different parts of a Dockerfile ([#147](https://github.com/docker/vscode-extension/issues/147))
-    - a new `docker.extension.editor.dockerfileBuildStageDecorationLines` setting to toggle the divider lines, defaults to `true`
+- a new experimental `docker.extension.enableBuildDebugging` setting for developing and testing the upcoming build debugging feature
+  - this feature is under active development and is not ready for general use
 - Compose
   - update schema to the latest version
   - textDocument/completion
@@ -34,6 +32,15 @@ All notable changes to the Docker DX extension will be documented in this file.
   - textDocument/completion
     - prevent errors if an empty JSON object is the content of the YAML file ([docker/docker-language-server#330](https://github.com/docker/docker-language-server/issues/330))
     - check character offset before processing to prevent errors ([docker/docker-language-server#333](https://github.com/docker/docker-language-server/issues/333))
+
+## [0.11.0] - 2025-06-23
+
+### Added
+
+- Dockerfile
+  - include the Dockerfile Language Server written in TypeScript into the extension
+  - draw horizontal lines between each `FROM` instruction to help users visually distinguish the different parts of a Dockerfile ([#147](https://github.com/docker/vscode-extension/issues/147))
+    - a new `docker.extension.editor.dockerfileBuildStageDecorationLines` setting to toggle the divider lines, defaults to `true`
 
 ## [0.10.0] - 2025-06-12
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ The extension provides inline suggestions to generate a Bake target to correspon
 
 ![Suggesting Bake targets based on the content of the local Dockerfile](resources/readme/docker-bake-inline-completion.png)
 
+### Build Debugging (under development)
+
+This feature is under active development. Although some commands and configurations may be exposed through the user interface due to the nature of how Visual Studio Code handles extension contributions, it is not intended to be used by the general public.
+
 ## Builds
 
 [GitHub Actions](https://github.com/docker/vscode-extension/actions) builds eight `.vsix` files - one for each platform combination (Windows, macOS, Linux, Alpine Linux x `amd64`/`arm64`).

--- a/package.json
+++ b/package.json
@@ -127,8 +127,8 @@
       "properties": {
         "docker.extension.enableBuildDebugging": {
           "type": "boolean",
-          "description": "Enables build debugging. Note that changing this value requires a restart of Visual Studio Code to take effect.",
-          "markdownDescription": "Enable build debugging features from the Docker DX extension. Note that changing this value requires a **restart** of Visual Studio Code to take effect.",
+          "description": "Enables build debugging features from the Docker DX extension. This feature is under active development. Note that changing this value requires a restart of Visual Studio Code to take effect.",
+          "markdownDescription": "Enable build debugging features from the Docker DX extension. This feature is under active development. Note that changing this value requires a **restart** of Visual Studio Code to take effect.",
           "default": false,
           "tags": [
             "experimental"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,7 +91,7 @@ function registerCommands(ctx: vscode.ExtensionContext) {
   });
 }
 
-function registerCommand(
+export function registerCommand(
   ctx: vscode.ExtensionContext,
   id: string,
   commandCallback: (...args: any[]) => Promise<boolean>,


### PR DESCRIPTION
We should clearly indicate to the user that the feature is under active development and not intended for general use.

![image](https://github.com/user-attachments/assets/be1a7d0f-001b-4e6a-8bc6-783aec535cf4)