### PR TITLE
Prompt the user about the disabled debug setting when launching

### DIFF
--- a/src/dap/config.ts
+++ b/src/dap/config.ts
@@ -110,6 +110,19 @@ export function setupDebugging(ctx: vscode.ExtensionContext) {
       );
       return Promise.resolve(false);
     });
+
+    // the debugger is still contributed and technically registered because of package.json
+    ctx.subscriptions.push(
+      vscode.debug.registerDebugConfigurationProvider('dockerfile', {
+        resolveDebugConfiguration(): vscode.ProviderResult<vscode.DebugConfiguration> {
+          vscode.window.showErrorMessage(
+            'Build Debugging for Docker is an experimental feature that is under active development. ' +
+              'Enable the feature by toggling the docker.extension.enableBuildDebugging setting to true and restarting your client.',
+          );
+          return undefined;
+        },
+      }),
+    );
     return;
   }
 


### PR DESCRIPTION
If the user tries to debug a Dockerfile when the debug setting is disabled, we still want to be able to warn them that the feature is disabled and that they can opt-in if desired.