### PR TITLE
Show errors from the Docker Language Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- errors with the Docker Language Server will no longer be hidden
+
 ## [0.12.0] - 2025-07-09
 
 ### Added

--- a/src/utils/lsp/lsp.ts
+++ b/src/utils/lsp/lsp.ts
@@ -207,7 +207,6 @@ async function createNative(ctx: vscode.ExtensionContext): Promise<boolean> {
   const clientOptions: LanguageClientOptions = {
     progressOnInitialization: true,
     outputChannel: vscode.window.createOutputChannel('Docker Language Server'),
-    revealOutputChannelOn: RevealOutputChannelOn.Never,
     markdown: {
       isTrusted: false,
       supportHtml: true,


### PR DESCRIPTION
We do not need to suppress errors from the language server anymore as it is now pretty stable. Showing the errors will help inform our users and hopefully lead them to open bugs about any edge cases we have not been considering.