### PR TITLE
Fix working directory path for Buildx debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Docker DX extension will be documented in this file.
 ### Fixed
 
 - fix Dockerfile Language Server crash with tabbed heredoc delimiters ([#171](https://github.com/docker/vscode-extension/issues/171))
+- fix Buildx debugger integration so that it works on Windows ([#181](https://github.com/docker/vscode-extension/issues/181))
 
 ## [0.13.0] - 2025-07-17
 

--- a/src/dap/config.ts
+++ b/src/dap/config.ts
@@ -16,7 +16,7 @@ class DebugAdapterExecutableFactory
     }
 
     const options = {
-      cwd: session.workspaceFolder?.uri.path,
+      cwd: session.workspaceFolder?.uri.fsPath,
       env: { BUILDX_EXPERIMENTAL: '1' },
     };
 


### PR DESCRIPTION
On Windows, there is a leading slash which causes problems. By using fsPath instead we'll get a regular C:\ path.

This will fix #181.