### PR TITLE
dap: include additional launch configuration to customize the builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,10 @@
                 "description": "Stop the docker build on the first instruction.",
                 "default": false
               },
+              "builder": {
+                "type": "string",
+                "description": "Builder to use."
+              },
               "args": {
                 "type": "array",
                 "description": "Arguments to pass to the build."

--- a/src/dap/config.ts
+++ b/src/dap/config.ts
@@ -10,7 +10,11 @@ class DebugAdapterExecutableFactory
   createDebugAdapterDescriptor(
     session: vscode.DebugSession,
   ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-    var args = ['buildx', 'dap', 'build'];
+    var args = ['buildx'];
+    if (session.configuration?.builder) {
+      args = args.concat(['--builder', session.configuration?.builder]);
+    }
+    args = args.concat(['dap', 'build']);
     if (session.configuration?.args) {
       args = args.concat(session.configuration?.args);
     }


### PR DESCRIPTION

An additional property exists for the DAP launch configuration that
allows setting the `--builder` property for the `buildx` invocation.

This isn't normally possible through `args` because `args` places the
parameters after the invocation of `buildx` while the builder option has
to be before the `buildx` command.
