### PR TITLE
Add language configuration for dockerbake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- added a language configuration for the `dockerbake` language to improve the editing experience ([#184](https://github.com/docker/vscode-extension/issues/184))
+
 ## [0.14.0] - 2025-08-06
 
 ### Added

--- a/configs/dockerbake-language-configuration.json
+++ b/configs/dockerbake-language-configuration.json
@@ -1,0 +1,27 @@
+{
+  "comments": {
+    "blockComment": ["/*", "*/"],
+    "lineComment": {
+      "comment": "//",
+      "noIndent": false
+    }
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "/*", "close": " */", "notIn": ["string"] }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "activationEvents": [
     "onDebugResolve:dockerfile",
     "onDebugDynamicConfigurations:dockerfile",
-    "onLanguage:dockerbake",
     "onLanguage:dockercompose",
     "onLanguage:dockerfile"
   ],
@@ -49,7 +48,8 @@
         "filenames": [
           "docker-bake.hcl",
           "docker-bake.override.hcl"
-        ]
+        ],
+        "configuration": "./configs/dockerbake-language-configuration.json"
       }
     ],
     "grammars": [


### PR DESCRIPTION
## Problem Description

We do not have language configuration for `dockerbake` which means editing these files are less intuitive when compared to other files with a built-in configuration. Matching brackets are not highlighted or automatically inserted and you cannot easily toggle comments with the built-in commands in Visual Studio Code.

## Proposed Solution

Added a language configuration to the extension which will improve the editing experience by colouring brackets, inserting matching brackets, and more.

Fixes #184.

## Proof of Work

Here's a comparison that shows how the brackets will be coloured giving it a much improved face lift.

<img width="2068" height="1072" alt="image" src="https://github.com/user-attachments/assets/965b1e9f-a95b-4c54-bab7-cd656aa7e3e3" />