### PR TITLE
Use Prettier for formatting JSON files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 // Place your settings in this file to overwrite default and user settings.
 {
 	"editor.formatOnSave": true,
+	"[json]": {
+	  "editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
 	"[typescriptreact]": {
 	  "editor.defaultFormatter": "esbenp.prettier-vscode"
 	},


### PR DESCRIPTION
## Problem Description

Depending on a user's settings, saving the `package.json` file may cause the trailing newline character to be removed.

## Proposed Solution

Explicitly setting Prettier as the formatter for JSON files will ensure formatting stays consistent and pull requests will not be opened with the trailing newline character removed by mistake.