### PR TITLE
Remove working-directory from the build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,22 +97,17 @@ jobs:
             ext: ""
 
     steps:
-      - name: actions/checkout@v4 (docker/vscode-extension)
-        uses: actions/checkout@v4
-        with:
-          path: vscode-extension
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
 
-      - working-directory: vscode-extension
-        run: |
+      - run: |
           NODE_OS=${{ matrix.nodeos }} NODE_ARCH=${{ matrix.nodearch }} npm install
 
       - name: Set variables
         id: set-variables
-        working-directory: vscode-extension
         run: |
           VERSION=$(npm pkg get version | tr -d \")
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
@@ -125,7 +120,6 @@ jobs:
         env:
           VERSION: ${{ steps.set-variables.outputs.VERSION }}
           SHA: ${{ steps.set-variables.outputs.SHA }}
-        working-directory: vscode-extension
         run: |
           npm install -g @vscode/vsce
           vsce package --target ${{ matrix.os }}-${{ matrix.nodearch }} -o docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-$VERSION-$SHA.vsix
@@ -135,14 +129,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}-${{ steps.set-variables.outputs.SHA }}.vsix
-          path: vscode-extension/docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}-${{ steps.set-variables.outputs.SHA }}.vsix
+          path: docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}-${{ steps.set-variables.outputs.SHA }}.vsix
           if-no-files-found: error
 
       - name: Build the extension (refs/tags/v)
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           VERSION: ${{ steps.set-variables.outputs.VERSION }}
-        working-directory: vscode-extension
         run: |
           npm install -g @vscode/vsce
           vsce package --target ${{ matrix.os }}-${{ matrix.nodearch }} -o docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-$VERSION.vsix
@@ -152,7 +145,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           name: docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}.vsix
-          path: vscode-extension/docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}.vsix
+          path: docker-vscode-extension-${{ matrix.os }}-${{ matrix.nodearch }}-${{ steps.set-variables.outputs.VERSION }}.vsix
           if-no-files-found: error
 
       - uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8 https://github.com/softprops/action-gh-release/commit/c062e08bd532815e2082a85e87e3ef29c3e6d191


### PR DESCRIPTION
As the build no longer requires checking out the Docker Language Server's repository either, we should remove the use of the `working-directory` attribute to keep the build simple and easy to understand.