### PR TITLE
Upload test failure screenshots as artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,12 @@ jobs:
       - run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm test
         working-directory: vscode-extension
 
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: screenshots
+          path: /tmp/test-resources/screenshots/
+
   test-release:
     runs-on: ubuntu-latest
 
@@ -67,6 +73,12 @@ jobs:
       - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm test
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: screenshots
+          path: /tmp/test-resources/screenshots/
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If the test fails, we should capture the screenshots and upload them as artifacts to help with debugging.