### PR TITLE
Reword some of the debugging documentation

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -6,9 +6,11 @@
 
 ## Requirements
 
-To use the build debugging feature, you will need to have [Buildx](https://github.com/docker/buildx) installed. The minimum supported version is v0.28. You can get Buildx v0.28 by [installing Docker Desktop](https://docs.docker.com/install/) 4.46 or by [installing Buildx manually](https://github.com/docker/buildx?tab=readme-ov-file#manual-download).
+To use the build debugging feature, we recommend installing or updating to [Docker Desktop](https://docs.docker.com/install/) 4.46 or above. You may alternatively install Buildx manually by following the instructions [here](https://github.com/docker/buildx?tab=readme-ov-file#manual-download).
 
-1. Run `docker buildx version` to check your Buildx version.
+To _validate_ that your Buildx installation supports build debugging, run the following commands:
+
+1. Run `docker buildx version` to check that your Buildx version is v0.28.0 or greater.
 2. Run `BUILDX_EXPERIMENTAL=1 docker buildx dap` to check that the `dap` subcommand is available in your Buildx installation.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ The **Docker DX (Developer Experience)** Visual Studio Code extension enhances y
 
 ## Key features
 
-- [Dockerfile linting](https://docs.docker.com/reference/build-checks/): Get build warnings and best-practice suggestions via BuildKit and BuildX.
+- Dockerfile editing features: Code completion and syntax highlighting as well as [build warnings and best-practice suggestions](https://docs.docker.com/reference/build-checks/) via BuildKit and Buildx.
+- Dockerfile debugging features: Debug and step through a Dockerfile build with [Buildx](https://github.com/docker/buildx)
 - [Compose editing features](https://docs.docker.com/compose/): Provides contextual code completion, reference navigation, and schema descriptions in hovers.
 - [Bake editing features](https://docs.docker.com/build/bake/): Includes code completion, variable navigation, and inline suggestions for generating targets based on your Dockerfile stages.
 - Image vulnerability scanning (experimental): Flags references to container images with known vulnerabilities directly within Dockerfiles.


### PR DESCRIPTION
Clarify that the steps to run are simply for validating your Buildx installation. If the user has Buildx v0.28.0 or higher than there is no additional configuration needed on their end.