### PR TITLE
Improve launch configuration experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Docker DX extension will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- introduced a new `cwd` debug configuration attribute so that the working directory used to launch the debug adapter can be set ([#210](https://github.com/docker/vscode-extension/issues/210))
+
+### Fixed
+
+- correct the description to state that the `dockerfile` debug attribute has to be relative to the working directory ([#210](https://github.com/docker/vscode-extension/issues/210))
+
 ## [0.17.0] - 2025-09-17
 
 ### Added

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -32,7 +32,8 @@ For more complicated build configurations, you can use the `launch.json` to defi
   "request": "launch", // required, must not be modified
   "name": "Docker: Build", // required, configurable
   "dockerfile": "Dockerfile", // required, configurable
-  "contextPath": "${workspaceFolder}",
+  "contextPath": "${workspaceFolder}", // optional, defaults to ${workspaceFolder}
+  "cwd": "${workspaceFolder}", // optional, defaults to ${workspaceFolder}
   "target": "test", // optional, should be a build stage in the Dockerfile
   "args": [
     // additional arguments for the build command

--- a/package.json
+++ b/package.json
@@ -88,12 +88,18 @@
             "properties": {
               "dockerfile": {
                 "type": "string",
-                "description": "Relative path from the context to the dockerfile.",
+                "description": "Relative path to the Dockerfile from the working directory or an absolute path to the Dockerfile. Defaults to Dockerfile.",
+                "markdownDescription": "Relative path to the Dockerfile from the working directory or an absolute path to the Dockerfile. Defaults to `Dockerfile`.",
                 "default": "Dockerfile"
               },
               "contextPath": {
                 "type": "string",
-                "description": "Path to the context.",
+                "description": "Path to the context. Defaults to the workspace folder.",
+                "default": "${workspaceFolder}"
+              },
+              "cwd": {
+                "type": "string",
+                "description": "Absolute path to the working directory to start the debugger from. Defaults to the workspace folder.",
                 "default": "${workspaceFolder}"
               },
               "target": {

--- a/src/dap/config.ts
+++ b/src/dap/config.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import { registerCommand } from '../extension';
-import { getExtensionSetting } from '../utils/settings';
 
 export const DebugEditorContentsCommandId = 'docker.debug.editorContents';
 
@@ -20,7 +19,7 @@ class DebugAdapterExecutableFactory
     }
 
     const options = {
-      cwd: session.workspaceFolder?.uri.fsPath,
+      cwd: session.configuration.cwd ?? session.workspaceFolder?.uri.fsPath,
       env: { BUILDX_EXPERIMENTAL: '1' },
     };
 
@@ -44,6 +43,7 @@ class DockerfileConfigurationProvider
         config.request = 'launch';
         config.dockerfile = editor.document.uri.fsPath;
         config.contextPath = '${workspaceFolder}';
+        config.cwd = '${workspaceFolder}';
       }
     }
     return config;


### PR DESCRIPTION
The `dockerfile` attribute needs to be a relative path to the working directory so the description has been corrected. Although it is unlikely anyone needs to set the working directory for the debug adapter to run in, there is nothing to lose from exposing this attribute given that the `dockerfile` attribute has to be relative to it.

Fixes #210.