### PR TITLE
fix #110 Signed-off-by: Roman Balashov <ubermailbox@protonmail.ch>

### DIFF
--- a/build/downloader.mjs
+++ b/build/downloader.mjs
@@ -63,7 +63,7 @@ function getArch() {
     process.env['NODE_ARCH'] === undefined
       ? process.arch
       : process.env['NODE_ARCH'];
-  return arch === 'x64' ? 'amd64' : 'arm64';
+  return arch === 'x64' || arch === 'amd64' ? 'amd64' : 'arm64';
 }
 
 async function downloadLanguageServerBinary() {


### PR DESCRIPTION
## Problem Description
#110 
https://github.com/docker/vscode-extension/issues/110#issuecomment-3350215471

After further analisys, I found the culprit:
In https://github.com/docker/vscode-extension/commit/c1b40c718a971c432e3e2fc1dd5328e56279c5c5#diff-3212eeba6732c6a4ea6eb2bdceeab63e2e5d56ab840dbdca2a7097f6b6447abfR60  

The function currently returns 'arm64' for both 'x64' and 'amd64'.

## Proposed Solution
Change function logic to return:
- **amd64** when process detects **x64** or **amd64**
- **arm64** in all other cases
 
`return arch === 'x64' || arch === 'amd64' ? 'amd64' : 'arm64';`

## Proof of Work

```bash
~/Projects/vscode-extension]$ node
Welcome to Node.js v22.18.0.
Type ".help" for more information.
> function getArch() {
...   const arch =
...     process.env['NODE_ARCH'] === undefined
...       ? process.arch
...       : process.env['NODE_ARCH'];
...   return arch === 'x64' || arch === 'amd64' ? 'amd64' : 'arm64';
... }
undefined
> getArch();
'amd64'
> process.arch;
'x64'
> process.env['NODE_ARCH'];
undefined
```