### PR TITLE
Remove the "Build with Debugger" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the Docker DX extension will be documented in this file.
 
 - correct the description to state that the `dockerfile` debug attribute has to be relative to the working directory ([#210](https://github.com/docker/vscode-extension/issues/210))
 
+### Removed
+
+- removed the "Build with Debugger" command (`docker.debug.editorContents`) as it is no longer necessary now that launch configurations have been implemented
+
 ## [0.17.0] - 2025-09-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -36,10 +36,6 @@
         "title": "Scan for CVEs with Docker Scout",
         "command": "docker.scout.imageScan",
         "enablement": "(view == dockerImages || view == vscode-containers.views.images) && viewItem == image"
-      },
-      {
-        "title": "Build with Debugger",
-        "command": "docker.debug.editorContents"
       }
     ],
     "languages": [

--- a/src/dap/config.ts
+++ b/src/dap/config.ts
@@ -106,29 +106,6 @@ class DockerfileDebugAdapterTracker implements vscode.DebugAdapterTracker {
 
 export function setupDebugging(ctx: vscode.ExtensionContext) {
   let channel = vscode.window.createOutputChannel('Docker Buildx DAP', 'log');
-
-  registerCommand(
-    ctx,
-    DebugEditorContentsCommandId,
-    async (resource: vscode.Uri) => {
-      let targetResource = resource;
-      if (!targetResource && vscode.window.activeTextEditor) {
-        targetResource = vscode.window.activeTextEditor.document.uri;
-      }
-      if (targetResource) {
-        vscode.debug.startDebugging(undefined, {
-          type: 'dockerfile',
-          name: 'Docker: Build',
-          request: 'launch',
-          dockerfile: targetResource.fsPath,
-          contextPath: '${workspaceFolder}',
-        });
-        return Promise.resolve(true);
-      }
-      return Promise.resolve(false);
-    },
-  );
-
   ctx.subscriptions.push(
     vscode.debug.registerDebugConfigurationProvider(
       'dockerfile',


### PR DESCRIPTION
This command is no longer necessary. Users can now debug a Dockerfile with or without a launch configuration.