### PR TITLE
Capture Buildx version in the telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Docker DX extension will be documented in this file.
 ### Added
 
 - introduced a new `cwd` debug configuration attribute so that the working directory used to launch the debug adapter can be set ([#210](https://github.com/docker/vscode-extension/issues/210))
+- record the system's version of Buildx in the telemetry ([#218](https://github.com/docker/vscode-extension/issues/218))
 
 ### Fixed
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -21,6 +21,7 @@ If you have already opted out of sending telemetry in Visual Studio Code then no
 - `vscode.env.sessionId`
 - version of the installed extension
 - Docker version
+- Buildx version
 - function names and parameters for diagnosing errors and crashes
 - error messages when the language server is unable to start or is crashing
 - if certain extensions are also installed


### PR DESCRIPTION
It would be beneficial to know what versions of Buildx our users have installed as our new debugging features depend on a specific minimum version of Buildx.

Fixes #218.