### PR TITLE
Record when a debug session is configured and started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Docker DX extension will be documented in this file.
 
 - introduced a new `cwd` debug configuration attribute so that the working directory used to launch the debug adapter can be set ([#210](https://github.com/docker/vscode-extension/issues/210))
 - record the system's version of Buildx in the telemetry ([#218](https://github.com/docker/vscode-extension/issues/218))
+- record telemetry when any Buildx debug session is started ([#226](https://github.com/docker/vscode-extension/issues/226))
 - Compose
   - update schema to the latest version
 
@@ -19,7 +20,6 @@ All notable changes to the Docker DX extension will be documented in this file.
 ### Fixed
 
 - correct the description to state that the `dockerfile` debug attribute has to be relative to the working directory ([#210](https://github.com/docker/vscode-extension/issues/210))
-
 - Bake
   - correct the schema for the `output` attribute of the `target` block so that the list can also contain objects instead of only strings ([docker/docker-language-server#77](https://github.com/docker/docker-language-server/issues/77))
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -22,6 +22,7 @@ If you have already opted out of sending telemetry in Visual Studio Code then no
 - version of the installed extension
 - Docker version
 - Buildx version
+- number of Buildx debug sessions that are started
 - function names and parameters for diagnosing errors and crashes
 - error messages when the language server is unable to start or is crashing
 - if certain extensions are also installed

--- a/src/dap/config.ts
+++ b/src/dap/config.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { registerCommand } from '../extension';
+import { queueTelemetryEvent } from '../telemetry/client';
 
 export const DebugEditorContentsCommandId = 'docker.debug.editorContents';
 
@@ -9,6 +9,11 @@ class DebugAdapterExecutableFactory
   createDebugAdapterDescriptor(
     session: vscode.DebugSession,
   ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+    queueTelemetryEvent('client_user_action', false, {
+      action_id: 'docker.buildx.debug.createDebugAdapterDescriptor',
+      result: true,
+    });
+
     var args = ['buildx'];
     if (session.configuration?.builder) {
       args = args.concat(['--builder', session.configuration?.builder]);
@@ -34,6 +39,13 @@ class DockerfileConfigurationProvider
     _folder: vscode.WorkspaceFolder | undefined,
     config: vscode.DebugConfiguration,
   ): vscode.ProviderResult<vscode.DebugConfiguration> {
+    // Check if the user is launching as-is without any attributes specified
+    const result = Object.keys(config).length === 0 ? 'undefined' : 'defined';
+    queueTelemetryEvent('client_user_action', false, {
+      action_id: 'docker.buildx.debug.resolveDebugConfiguration',
+      result: result,
+    });
+
     // this can happen when debugging without anything in launch.json
     if (!config.type && !config.request && !config.name) {
       const editor = vscode.window.activeTextEditor;


### PR DESCRIPTION
## Problem Description

We want to understand the usage of the new Buildx debugger support we have introduced to the extension.

## Proposed Solution

We will capture the number of times a debug session is configured or used. This will only apply for Buildx debugger sessions. If you debug a random Node.js application, that information is not captured.

Fixes #226.