### PR TITLE
Add environment variable for dap metrics to report user agent

### DIFF
--- a/src/dap/config.ts
+++ b/src/dap/config.ts
@@ -25,7 +25,10 @@ class DebugAdapterExecutableFactory
 
     const options = {
       cwd: session.configuration.cwd ?? session.workspaceFolder?.uri.fsPath,
-      env: { BUILDX_EXPERIMENTAL: '1' },
+      env: {
+        BUILDX_EXPERIMENTAL: '1',
+        BUILDX_DAP_USER_AGENT: 'vscode/docker-dx',
+      },
     };
 
     return new vscode.DebugAdapterExecutable('docker', args, options);


### PR DESCRIPTION

This adds an environment variable for the `buildx dap build` command to
report the invoking user for reporting metrics. This will help us
identify which `dap` invocations are done from this plugin when metrics
are enabled for docker desktop.

Related to https://github.com/docker/buildx/pull/3633.
