### PR TITLE
Update the build's Go version to match the latest docker-language-server code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '1.23.8'
+          go-version: '1.25.5'
 
       - run: npm ci
         working-directory: vscode-extension


### PR DESCRIPTION
The `go.mod` uses 1.25.5 at the moment so we'll update this to see where it gets us.